### PR TITLE
test: add direct notebook execution to all five notebook CI gates (closes #373)

### DIFF
--- a/tests/test_math/test_demo_notebook.py
+++ b/tests/test_math/test_demo_notebook.py
@@ -16,12 +16,18 @@ Covered API surface:
 
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
+
 import numpy as np
 import plotly.graph_objects as go
 import polars as pl
 import pytest
 
 from basanos.math import BasanosConfig, BasanosEngine
+
+_NOTEBOOK = Path(__file__).parents[2] / "book/marimo/notebooks/demo.py"
 
 # ─── Constants (mirror cell_04 of the notebook) ───────────────────────────────
 
@@ -183,3 +189,29 @@ class TestDemoPortfolioPlots:
     def test_correlation_heatmap_returns_plotly_figure(self, demo_engine: BasanosEngine) -> None:
         fig = demo_engine.portfolio.plots.correlation_heatmap()
         assert isinstance(fig, go.Figure)
+
+
+# ─── Direct notebook execution ───────────────────────────────────────────────
+
+
+def test_notebook_executes() -> None:
+    """Execute demo.py directly via marimo export html (no sandbox).
+
+    This catches regressions in notebook cell code itself, not just the API
+    that the mirror tests validate.
+    """
+    result = subprocess.run(  # nosec
+        [sys.executable, "-m", "marimo", "export", "html", str(_NOTEBOOK), "-o", "/dev/null"],
+        capture_output=True,
+        text=True,
+    )
+    combined = (result.stdout or "") + "\n" + (result.stderr or "")
+    failure_keywords = ["cells failed to execute", "marimoexceptionraisederror"]
+    for kw in failure_keywords:
+        assert kw.lower() not in combined.lower(), (
+            f"Notebook {_NOTEBOOK.name} reported cell failures (keyword '{kw}'):\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+    assert result.returncode == 0, (
+        f"marimo export returned non-zero for {_NOTEBOOK.name}:\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+    )

--- a/tests/test_math/test_diagnostics_notebook.py
+++ b/tests/test_math/test_diagnostics_notebook.py
@@ -20,13 +20,18 @@ after the notebook was first written, making this gate especially important.
 from __future__ import annotations
 
 import math
+import subprocess
+import sys
 from datetime import date
+from pathlib import Path
 
 import numpy as np
 import polars as pl
 import pytest
 
 from basanos.math import BasanosConfig, BasanosEngine, SlidingWindowConfig
+
+_NOTEBOOK = Path(__file__).parents[2] / "book/marimo/notebooks/diagnostics.py"
 
 # ─── Shared constants (mirror the notebook) ──────────────────────────────────
 
@@ -348,3 +353,29 @@ class TestSignalUtilisationSw:
     def test_row_count(self, sw_engine: BasanosEngine, notebook_prices: pl.DataFrame) -> None:
         """signal_utilisation must have one row per price timestamp."""
         assert sw_engine.signal_utilisation.height == notebook_prices.height
+
+
+# ─── Direct notebook execution ───────────────────────────────────────────────
+
+
+def test_notebook_executes() -> None:
+    """Execute diagnostics.py directly via marimo export html (no sandbox).
+
+    This catches regressions in notebook cell code itself, not just the API
+    that the mirror tests validate.
+    """
+    result = subprocess.run(  # nosec
+        [sys.executable, "-m", "marimo", "export", "html", str(_NOTEBOOK), "-o", "/dev/null"],
+        capture_output=True,
+        text=True,
+    )
+    combined = (result.stdout or "") + "\n" + (result.stderr or "")
+    failure_keywords = ["cells failed to execute", "marimoexceptionraisederror"]
+    for kw in failure_keywords:
+        assert kw.lower() not in combined.lower(), (
+            f"Notebook {_NOTEBOOK.name} reported cell failures (keyword '{kw}'):\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+    assert result.returncode == 0, (
+        f"marimo export returned non-zero for {_NOTEBOOK.name}:\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+    )

--- a/tests/test_math/test_ewm_benchmark_notebook.py
+++ b/tests/test_math/test_ewm_benchmark_notebook.py
@@ -18,11 +18,17 @@ not installed.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest
 
 from basanos.math import ewm_corr as ewm_corr_numpy
+
+_NOTEBOOK = Path(__file__).parents[2] / "book/marimo/notebooks/ewm_benchmark.py"
 
 # ─── Pandas reference implementation (mirrors notebook setup cell) ────────────
 
@@ -142,3 +148,29 @@ class TestEwmCorrNumpyVsPandas:
         rng = np.random.default_rng(7)
         data = rng.normal(size=(200, 1))
         self._compare(data, 20)
+
+
+# ─── Direct notebook execution ───────────────────────────────────────────────
+
+
+def test_notebook_executes() -> None:
+    """Execute ewm_benchmark.py directly via marimo export html (no sandbox).
+
+    This catches regressions in notebook cell code itself, not just the API
+    that the mirror tests validate.
+    """
+    result = subprocess.run(  # nosec
+        [sys.executable, "-m", "marimo", "export", "html", str(_NOTEBOOK), "-o", "/dev/null"],
+        capture_output=True,
+        text=True,
+    )
+    combined = (result.stdout or "") + "\n" + (result.stderr or "")
+    failure_keywords = ["cells failed to execute", "marimoexceptionraisederror"]
+    for kw in failure_keywords:
+        assert kw.lower() not in combined.lower(), (
+            f"Notebook {_NOTEBOOK.name} reported cell failures (keyword '{kw}'):\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+    assert result.returncode == 0, (
+        f"marimo export returned non-zero for {_NOTEBOOK.name}:\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+    )

--- a/tests/test_math/test_factor_model_notebook.py
+++ b/tests/test_math/test_factor_model_notebook.py
@@ -15,10 +15,16 @@ Covered API surface:
 
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
+
 import numpy as np
 import pytest
 
 from basanos.math import FactorModel
+
+_NOTEBOOK = Path(__file__).parents[2] / "book/marimo/notebooks/factor_model_guide.py"
 
 # ─── Manual-example constants (mirror cell_04) ───────────────────────────────
 
@@ -188,3 +194,29 @@ class TestFactorModelWoodburySolve:
         x_woodbury = fm_manual.solve(b)
         x_direct = np.linalg.solve(fm_manual.covariance, b)
         np.testing.assert_allclose(x_woodbury, x_direct, rtol=1e-8, atol=1e-10)
+
+
+# ─── Direct notebook execution ───────────────────────────────────────────────
+
+
+def test_notebook_executes() -> None:
+    """Execute factor_model_guide.py directly via marimo export html (no sandbox).
+
+    This catches regressions in notebook cell code itself, not just the API
+    that the mirror tests validate.
+    """
+    result = subprocess.run(  # nosec
+        [sys.executable, "-m", "marimo", "export", "html", str(_NOTEBOOK), "-o", "/dev/null"],
+        capture_output=True,
+        text=True,
+    )
+    combined = (result.stdout or "") + "\n" + (result.stderr or "")
+    failure_keywords = ["cells failed to execute", "marimoexceptionraisederror"]
+    for kw in failure_keywords:
+        assert kw.lower() not in combined.lower(), (
+            f"Notebook {_NOTEBOOK.name} reported cell failures (keyword '{kw}'):\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+    assert result.returncode == 0, (
+        f"marimo export returned non-zero for {_NOTEBOOK.name}:\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+    )

--- a/tests/test_math/test_shrinkage_notebook.py
+++ b/tests/test_math/test_shrinkage_notebook.py
@@ -17,6 +17,10 @@ Covered API surface:
 
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
+
 import numpy as np
 import plotly.graph_objects as go
 import polars as pl
@@ -24,6 +28,8 @@ import pytest
 
 from basanos.math import BasanosConfig, BasanosEngine
 from basanos.math._signal import shrink2id
+
+_NOTEBOOK = Path(__file__).parents[2] / "book/marimo/notebooks/shrinkage_guide.py"
 
 # ─── Constants (mirror cell_05 of the notebook) ───────────────────────────────
 
@@ -182,3 +188,29 @@ class TestConditionNumberVsShrinkage:
         eigvals = np.linalg.eigvalsh(shrunk)
         kappa = eigvals[-1] / max(eigvals[0], 1e-14)
         np.testing.assert_allclose(kappa, 1.0, atol=1e-10)
+
+
+# ─── Direct notebook execution ───────────────────────────────────────────────
+
+
+def test_notebook_executes() -> None:
+    """Execute shrinkage_guide.py directly via marimo export html (no sandbox).
+
+    This catches regressions in notebook cell code itself, not just the API
+    that the mirror tests validate.
+    """
+    result = subprocess.run(  # nosec
+        [sys.executable, "-m", "marimo", "export", "html", str(_NOTEBOOK), "-o", "/dev/null"],
+        capture_output=True,
+        text=True,
+    )
+    combined = (result.stdout or "") + "\n" + (result.stderr or "")
+    failure_keywords = ["cells failed to execute", "marimoexceptionraisederror"]
+    for kw in failure_keywords:
+        assert kw.lower() not in combined.lower(), (
+            f"Notebook {_NOTEBOOK.name} reported cell failures (keyword '{kw}'):\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+    assert result.returncode == 0, (
+        f"marimo export returned non-zero for {_NOTEBOOK.name}:\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

- Added `test_notebook_executes()` to all five notebook test files in `tests/test_math/`
- Each function runs the corresponding notebook via `python -m marimo export html` (no sandbox, uses current test env)
- Checks exit code and known marimo failure keywords (`cells failed to execute`, `marimoexceptionraisederror`)
- Keeps existing API-mirror tests — two-layer coverage as suggested in the issue notes

## Test plan

- [ ] All 5 new `test_notebook_executes` tests pass locally (verified: 5 passed in 39s)
- [ ] Existing mirror tests unchanged and continue to pass
- [ ] `make test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)