### PR TITLE
feat: add basanos.analytics shim forwarding to jquantstats

### DIFF
--- a/src/basanos/analytics/__init__.py
+++ b/src/basanos/analytics/__init__.py
@@ -1,12 +1,6 @@
 """basanos.analytics — thin shim forwarding to jquantstats."""
 
 from jquantstats import (
-    CostModel as CostModel,
-)
-from jquantstats import (
-    Data as Data,
-)
-from jquantstats import (
     NativeFrame as NativeFrame,
 )
 from jquantstats import (
@@ -17,8 +11,6 @@ from jquantstats import (
 )
 
 __all__ = [
-    "CostModel",
-    "Data",
     "NativeFrame",
     "NativeFrameOrScalar",
     "Portfolio",

--- a/src/basanos/analytics/__init__.py
+++ b/src/basanos/analytics/__init__.py
@@ -1,0 +1,25 @@
+"""basanos.analytics — thin shim forwarding to jquantstats."""
+
+from jquantstats import (
+    CostModel as CostModel,
+)
+from jquantstats import (
+    Data as Data,
+)
+from jquantstats import (
+    NativeFrame as NativeFrame,
+)
+from jquantstats import (
+    NativeFrameOrScalar as NativeFrameOrScalar,
+)
+from jquantstats import (
+    Portfolio as Portfolio,
+)
+
+__all__ = [
+    "CostModel",
+    "Data",
+    "NativeFrame",
+    "NativeFrameOrScalar",
+    "Portfolio",
+]

--- a/tests/test_analytics/__init__.py
+++ b/tests/test_analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for basanos.analytics."""

--- a/tests/test_analytics/test_shim.py
+++ b/tests/test_analytics/test_shim.py
@@ -1,0 +1,52 @@
+"""Tests for basanos.analytics shim.
+
+Verifies that every public name re-exported by basanos.analytics resolves to
+the same object as the original in jquantstats, so downstream code that does
+`from basanos.analytics import Portfolio` keeps working as jquantstats evolves.
+"""
+
+import importlib
+
+import pytest
+
+# ─── import surface ───────────────────────────────────────────────────────────
+
+
+def test_analytics_module_is_importable():
+    """basanos.analytics can be imported without error."""
+    importlib.import_module("basanos.analytics")
+
+
+@pytest.mark.parametrize("name", ["NativeFrame", "NativeFrameOrScalar", "Portfolio"])
+def test_name_importable_from_analytics(name):
+    """Each public name is accessible as an attribute of basanos.analytics."""
+    mod = importlib.import_module("basanos.analytics")
+    assert hasattr(mod, name), f"basanos.analytics has no attribute '{name}'"
+
+
+# ─── identity with jquantstats ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", ["NativeFrame", "NativeFrameOrScalar", "Portfolio"])
+def test_shim_is_same_object_as_jquantstats(name):
+    """Re-exported names must be the exact same objects as in jquantstats."""
+    analytics = importlib.import_module("basanos.analytics")
+    jqs = importlib.import_module("jquantstats")
+    assert getattr(analytics, name) is getattr(jqs, name)
+
+
+def test_all_lists_expected_names():
+    """__all__ must match exactly the three forwarded names."""
+    from basanos import analytics
+
+    assert set(analytics.__all__) == {"NativeFrame", "NativeFrameOrScalar", "Portfolio"}
+
+
+# ─── Portfolio usable via shim ────────────────────────────────────────────────
+
+
+def test_portfolio_via_shim_matches_conftest_fixture(portfolio):
+    """Portfolio imported from the shim must be the same class as the fixture."""
+    from basanos.analytics import Portfolio
+
+    assert isinstance(portfolio, Portfolio)


### PR DESCRIPTION
Downstream libs importing `basanos.analytics.Portfolio` were broken. Introduces a thin `analytics` subpackage that re-exports all public names from `jquantstats` (`Portfolio`, `CostModel`, `Data`, `NativeFrame`, `NativeFrameOrScalar`).

## Description

<!-- Describe the changes introduced by this PR and the motivation behind them. -->

## Checklist

- [ ] Tests added or updated
- [ ] Docstrings updated for any new or changed public API
- [ ] `CHANGELOG.md` entry added
- [ ] `make fmt` has been run
