### PR TITLE
Feat/ic horizon parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** All IC functions (`ic`, `rank_ic`, `ic_mean`, `ic_std`, `icir`,
+  `rank_ic_mean`, `rank_ic_std`) converted from properties to methods accepting
+  a horizon parameter `h: int = 1`. Existing code using `engine.ic` must be
+  updated to `engine.ic()`. Use `h > 1` to evaluate signal quality against
+  multi-period forward returns (e.g. `engine.ic(h=5)` for 5-day IC).
+
 ## [0.6.0] - 2026-03-27
 
 ### Added

--- a/book/marimo/notebooks/end_to_end.py
+++ b/book/marimo/notebooks/end_to_end.py
@@ -13,7 +13,7 @@
 
 import marimo
 
-__generated_with = "0.20.4"
+__generated_with = "0.23.2"
 app = marimo.App(width="medium")
 
 with app.setup:
@@ -49,12 +49,14 @@ def cell_01():
         > no external data sources, API keys, or network access required.
         """
     )
+    return
 
 
 @app.cell
 def cell_02():
     """Render separator."""
     mo.md(r"""---""")
+    return
 
 
 @app.cell
@@ -78,6 +80,7 @@ def cell_03():
         for robust EWMA warmup and meaningful out-of-sample statistics.
         """
     )
+    return
 
 
 @app.cell
@@ -169,12 +172,14 @@ def cell_05(mu, prices):
             ),
         ]
     )
+    return
 
 
 @app.cell
 def cell_06():
     """Render separator."""
     mo.md(r"""---""")
+    return
 
 
 @app.cell
@@ -211,6 +216,7 @@ def cell_07():
         Use the sliders to explore how each parameter affects the strategy.
         """
     )
+    return
 
 
 @app.cell
@@ -294,6 +300,7 @@ def cell_09(clip_slider, corr_slider, shrink_slider, vola_slider):
 def cell_10():
     """Render separator."""
     mo.md(r"""---""")
+    return
 
 
 @app.cell
@@ -321,6 +328,7 @@ def cell_11():
            EWMA volatility.
         """
     )
+    return
 
 
 @app.cell
@@ -353,12 +361,13 @@ def cell_13(engine):
             ),
             mo.md(
                 f"### Signal quality\n\n"
-                f"- **IC mean**: `{engine.ic_mean:.4f}` | **IC std**: `{engine.ic_std:.4f}`\n"
-                f"- **ICIR**: `{engine.icir:.4f}`\n"
-                f"- **Rank IC mean**: `{engine.rank_ic_mean:.4f}` | **Rank IC std**: `{engine.rank_ic_std:.4f}`\n"
+                f"- **IC mean**: `{engine.ic_mean():.4f}` | **IC std**: `{engine.ic_std():.4f}`\n"
+                f"- **ICIR**: `{engine.icir():.4f}`\n"
+                f"- **Rank IC mean**: `{engine.rank_ic_mean():.4f}` | **Rank IC std**: `{engine.rank_ic_std():.4f}`\n"
             ),
         ]
     )
+    return
 
 
 @app.cell
@@ -376,6 +385,7 @@ def cell_14(portfolio):
             mo.ui.table(portfolio.turnover_summary()),
         ]
     )
+    return
 
 
 @app.cell
@@ -396,12 +406,14 @@ def cell_15(portfolio):
             mo.ui.plotly(portfolio.plots.snapshot()),
         ]
     )
+    return
 
 
 @app.cell
 def cell_16():
     """Render separator."""
     mo.md(r"""---""")
+    return
 
 
 @app.cell
@@ -434,6 +446,7 @@ def cell_17():
         The cell below saves the report to a temporary path and confirms success.
         """
     )
+    return
 
 
 @app.cell
@@ -464,12 +477,14 @@ def cell_18(portfolio):
         ),
         kind="success",
     )
+    return
 
 
 @app.cell
 def cell_19():
     """Render separator."""
     mo.md(r"""---""")
+    return
 
 
 @app.cell
@@ -493,6 +508,7 @@ def cell_20():
         Use the slider to set the maximum cost level to evaluate.
         """
     )
+    return
 
 
 @app.cell
@@ -530,6 +546,7 @@ def cell_22(max_bps_slider, portfolio):
             mo.md(f"*{_be_note}  One-way cost in basis points per unit of AUM traded.*"),
         ]
     )
+    return
 
 
 @app.cell
@@ -549,12 +566,14 @@ def cell_23(portfolio):
             mo.ui.plotly(portfolio.plots.trading_cost_impact_plot()),
         ]
     )
+    return
 
 
 @app.cell
 def cell_24():
     """Render separator."""
     mo.md(r"""---""")
+    return
 
 
 @app.cell
@@ -596,6 +615,7 @@ def cell_25():
           the full API reference
         """
     )
+    return
 
 
 if __name__ == "__main__":

--- a/src/basanos/math/_engine_ic.py
+++ b/src/basanos/math/_engine_ic.py
@@ -31,23 +31,33 @@ class _SignalEvaluatorMixin:
     * ``mu`` — Polars DataFrame of expected-return signals
     """
 
-    def _ic_series(self: _EngineProtocol, use_rank: bool) -> pl.DataFrame:
+    def _ic_series(self: _EngineProtocol, use_rank: bool, h: int = 1) -> pl.DataFrame:
         """Compute the cross-sectional IC time series.
 
-        For each timestamp *t* (from 0 to T-2), correlates the signal vector
-        ``mu[t, :]`` with the one-period forward return vector
-        ``prices[t+1, :] / prices[t, :] - 1`` across all assets where both
+        For each timestamp *t* (from 0 to T-1-h), correlates the signal vector
+        ``mu[t, :]`` with the *h*-period forward return vector
+        ``prices[t+h, :] / prices[t, :] - 1`` across all assets where both
         quantities are finite.  When fewer than two valid asset pairs are
         available, the IC value is set to ``NaN``.
 
         Args:
             use_rank: When ``True`` the Spearman rank correlation is used
                 (Rank IC); when ``False`` the Pearson correlation is used (IC).
+            h: Forward-return horizon in periods.  ``h=1`` (default) gives the
+                classic one-period IC; ``h=5`` evaluates signal quality against
+                five-period returns.  Must be >= 1.
 
         Returns:
             pl.DataFrame: Two-column frame with ``date`` (signal date) and
             either ``ic`` or ``rank_ic``.
+
+        Raises:
+            ValueError: If *h* < 1.
         """
+        if h < 1:
+            msg = f"h must be >= 1, got {h}"
+            raise ValueError(msg)
+
         assets = self.assets
         prices_np = self.prices.select(assets).to_numpy().astype(float)
         mu_np = self.mu.select(assets).to_numpy().astype(float)
@@ -57,8 +67,8 @@ class _SignalEvaluatorMixin:
         ic_values: list[float] = []
         ic_dates = []
 
-        for t in range(len(dates) - 1):
-            fwd_ret = prices_np[t + 1] / prices_np[t] - 1.0
+        for t in range(len(dates) - h):
+            fwd_ret = prices_np[t + h] / prices_np[t] - 1.0
             signal = mu_np[t]
 
             # Both signal and forward return must be finite
@@ -77,18 +87,20 @@ class _SignalEvaluatorMixin:
 
         return pl.DataFrame({"date": ic_dates, col_name: pl.Series(ic_values, dtype=pl.Float64)})
 
-    @property
-    def ic(self: _EngineProtocol) -> pl.DataFrame:
+    def ic(self: _EngineProtocol, h: int = 1) -> pl.DataFrame:
         """Cross-sectional Pearson Information Coefficient (IC) time series.
 
-        For each timestamp *t* (excluding the last), computes the Pearson
-        correlation between the signal ``mu[t, :]`` and the one-period forward
-        return ``prices[t+1, :] / prices[t, :] - 1`` across all assets where
-        both quantities are finite.
+        For each timestamp *t*, computes the Pearson correlation between the
+        signal ``mu[t, :]`` and the *h*-period forward return
+        ``prices[t+h, :] / prices[t, :] - 1`` across all assets where both
+        quantities are finite.
 
         An IC value close to +1 means the signal ranked assets in the same
         order as forward returns; close to -1 means the opposite; near 0 means
         no predictive relationship.
+
+        Args:
+            h: Forward-return horizon in periods (default 1).
 
         Returns:
             pl.DataFrame: Frame with columns ``['date', 'ic']``.  ``date`` is
@@ -101,15 +113,17 @@ class _SignalEvaluatorMixin:
             `ic_mean`, `ic_std`, `icir` — summary
             statistics.
         """
-        return self._ic_series(use_rank=False)
+        return self._ic_series(use_rank=False, h=h)
 
-    @property
-    def rank_ic(self: _EngineProtocol) -> pl.DataFrame:
+    def rank_ic(self: _EngineProtocol, h: int = 1) -> pl.DataFrame:
         """Cross-sectional Spearman Rank Information Coefficient time series.
 
         Identical to `ic` but uses the Spearman rank correlation
         instead of the Pearson correlation, making it more robust to fat-tailed
         return distributions and outliers.
+
+        Args:
+            h: Forward-return horizon in periods (default 1).
 
         Returns:
             pl.DataFrame: Frame with columns ``['date', 'rank_ic']``.
@@ -120,74 +134,84 @@ class _SignalEvaluatorMixin:
             `rank_ic_mean`, `rank_ic_std` — summary
             statistics.
         """
-        return self._ic_series(use_rank=True)
+        return self._ic_series(use_rank=True, h=h)
 
-    @property
-    def ic_mean(self) -> float:
+    def ic_mean(self, h: int = 1) -> float:
         """Mean of the IC time series, ignoring NaN values.
+
+        Args:
+            h: Forward-return horizon in periods (default 1).
 
         Returns:
             float: Arithmetic mean of all finite IC values, or ``NaN`` if
             no finite values exist.
         """
-        arr = self.ic["ic"].drop_nulls().to_numpy()
+        arr = self.ic(h)["ic"].drop_nulls().to_numpy()
         finite = arr[np.isfinite(arr)]
         return float(np.mean(finite)) if len(finite) > 0 else float("nan")
 
-    @property
-    def ic_std(self) -> float:
+    def ic_std(self, h: int = 1) -> float:
         """Standard deviation of the IC time series, ignoring NaN values.
 
         Uses ``ddof=1`` (sample standard deviation).
+
+        Args:
+            h: Forward-return horizon in periods (default 1).
 
         Returns:
             float: Sample standard deviation of all finite IC values, or
             ``NaN`` if fewer than 2 finite values exist.
         """
-        arr = self.ic["ic"].drop_nulls().to_numpy()
+        arr = self.ic(h)["ic"].drop_nulls().to_numpy()
         finite = arr[np.isfinite(arr)]
         return float(np.std(finite, ddof=1)) if len(finite) > 1 else float("nan")
 
-    @property
-    def icir(self) -> float:
+    def icir(self, h: int = 1) -> float:
         """Information Coefficient Information Ratio (ICIR).
 
         Defined as ``IC mean / IC std``.  A higher absolute ICIR indicates a
         more consistent signal: the mean IC is large relative to its
         variability.
 
+        Args:
+            h: Forward-return horizon in periods (default 1).
+
         Returns:
             float: ``ic_mean / ic_std``, or ``NaN`` when ``ic_std`` is zero
             or non-finite.
         """
-        mean = self.ic_mean
-        std = self.ic_std
+        mean = self.ic_mean(h)
+        std = self.ic_std(h)
         if not np.isfinite(std) or std == 0.0:
             return float("nan")
         return float(mean / std)
 
-    @property
-    def rank_ic_mean(self) -> float:
+    def rank_ic_mean(self, h: int = 1) -> float:
         """Mean of the Rank IC time series, ignoring NaN values.
+
+        Args:
+            h: Forward-return horizon in periods (default 1).
 
         Returns:
             float: Arithmetic mean of all finite Rank IC values, or ``NaN``
             if no finite values exist.
         """
-        arr = self.rank_ic["rank_ic"].drop_nulls().to_numpy()
+        arr = self.rank_ic(h)["rank_ic"].drop_nulls().to_numpy()
         finite = arr[np.isfinite(arr)]
         return float(np.mean(finite)) if len(finite) > 0 else float("nan")
 
-    @property
-    def rank_ic_std(self) -> float:
+    def rank_ic_std(self, h: int = 1) -> float:
         """Standard deviation of the Rank IC time series, ignoring NaN values.
 
         Uses ``ddof=1`` (sample standard deviation).
+
+        Args:
+            h: Forward-return horizon in periods (default 1).
 
         Returns:
             float: Sample standard deviation of all finite Rank IC values, or
             ``NaN`` if fewer than 2 finite values exist.
         """
-        arr = self.rank_ic["rank_ic"].drop_nulls().to_numpy()
+        arr = self.rank_ic(h)["rank_ic"].drop_nulls().to_numpy()
         finite = arr[np.isfinite(arr)]
         return float(np.std(finite, ddof=1)) if len(finite) > 1 else float("nan")

--- a/src/basanos/math/_engine_ic.py
+++ b/src/basanos/math/_engine_ic.py
@@ -136,7 +136,7 @@ class _SignalEvaluatorMixin:
         """
         return self._ic_series(use_rank=True, h=h)
 
-    def ic_mean(self, h: int = 1) -> float:
+    def ic_mean(self: _EngineProtocol, h: int = 1) -> float:
         """Mean of the IC time series, ignoring NaN values.
 
         Args:
@@ -146,11 +146,11 @@ class _SignalEvaluatorMixin:
             float: Arithmetic mean of all finite IC values, or ``NaN`` if
             no finite values exist.
         """
-        arr = self.ic(h)["ic"].drop_nulls().to_numpy()
+        arr = self._ic_series(use_rank=False, h=h)["ic"].drop_nulls().to_numpy()
         finite = arr[np.isfinite(arr)]
         return float(np.mean(finite)) if len(finite) > 0 else float("nan")
 
-    def ic_std(self, h: int = 1) -> float:
+    def ic_std(self: _EngineProtocol, h: int = 1) -> float:
         """Standard deviation of the IC time series, ignoring NaN values.
 
         Uses ``ddof=1`` (sample standard deviation).
@@ -162,11 +162,11 @@ class _SignalEvaluatorMixin:
             float: Sample standard deviation of all finite IC values, or
             ``NaN`` if fewer than 2 finite values exist.
         """
-        arr = self.ic(h)["ic"].drop_nulls().to_numpy()
+        arr = self._ic_series(use_rank=False, h=h)["ic"].drop_nulls().to_numpy()
         finite = arr[np.isfinite(arr)]
         return float(np.std(finite, ddof=1)) if len(finite) > 1 else float("nan")
 
-    def icir(self, h: int = 1) -> float:
+    def icir(self: _EngineProtocol, h: int = 1) -> float:
         """Information Coefficient Information Ratio (ICIR).
 
         Defined as ``IC mean / IC std``.  A higher absolute ICIR indicates a
@@ -180,13 +180,16 @@ class _SignalEvaluatorMixin:
             float: ``ic_mean / ic_std``, or ``NaN`` when ``ic_std`` is zero
             or non-finite.
         """
-        mean = self.ic_mean(h)
-        std = self.ic_std(h)
+        ic_df = self._ic_series(use_rank=False, h=h)
+        arr = ic_df["ic"].drop_nulls().to_numpy()
+        finite = arr[np.isfinite(arr)]
+        mean = float(np.mean(finite)) if len(finite) > 0 else float("nan")
+        std = float(np.std(finite, ddof=1)) if len(finite) > 1 else float("nan")
         if not np.isfinite(std) or std == 0.0:
             return float("nan")
         return float(mean / std)
 
-    def rank_ic_mean(self, h: int = 1) -> float:
+    def rank_ic_mean(self: _EngineProtocol, h: int = 1) -> float:
         """Mean of the Rank IC time series, ignoring NaN values.
 
         Args:
@@ -196,11 +199,11 @@ class _SignalEvaluatorMixin:
             float: Arithmetic mean of all finite Rank IC values, or ``NaN``
             if no finite values exist.
         """
-        arr = self.rank_ic(h)["rank_ic"].drop_nulls().to_numpy()
+        arr = self._ic_series(use_rank=True, h=h)["rank_ic"].drop_nulls().to_numpy()
         finite = arr[np.isfinite(arr)]
         return float(np.mean(finite)) if len(finite) > 0 else float("nan")
 
-    def rank_ic_std(self, h: int = 1) -> float:
+    def rank_ic_std(self: _EngineProtocol, h: int = 1) -> float:
         """Standard deviation of the Rank IC time series, ignoring NaN values.
 
         Uses ``ddof=1`` (sample standard deviation).
@@ -212,6 +215,6 @@ class _SignalEvaluatorMixin:
             float: Sample standard deviation of all finite Rank IC values, or
             ``NaN`` if fewer than 2 finite values exist.
         """
-        arr = self.rank_ic(h)["rank_ic"].drop_nulls().to_numpy()
+        arr = self._ic_series(use_rank=True, h=h)["rank_ic"].drop_nulls().to_numpy()
         finite = arr[np.isfinite(arr)]
         return float(np.std(finite, ddof=1)) if len(finite) > 1 else float("nan")

--- a/src/basanos/math/_engine_protocol.py
+++ b/src/basanos/math/_engine_protocol.py
@@ -114,6 +114,6 @@ class _EngineProtocol(Protocol):
         """Yield ``(i, t, mask, pos_or_none, status)`` tuples over all timestamps."""
         ...
 
-    def _ic_series(self, use_rank: bool) -> pl.DataFrame:
+    def _ic_series(self, use_rank: bool, h: int = 1) -> pl.DataFrame:
         """Compute the cross-sectional IC time series."""
         ...

--- a/src/basanos/math/optimizer.py
+++ b/src/basanos/math/optimizer.py
@@ -234,8 +234,8 @@ class BasanosEngine(_DiagnosticsMixin, _SignalEvaluatorMixin, _SolveMixin):
       `sharpe_at_shrink`, `sharpe_at_window_factors`
     * **Matrix diagnostics** — `condition_number`, `effective_rank`,
       `solver_residual`, `signal_utilisation`
-    * **Signal evaluation** — `ic`, `rank_ic`, `ic_mean`, `ic_std`, `icir`,
-      `rank_ic_mean`, `rank_ic_std`
+    * **Signal evaluation** — `ic(h)`, `rank_ic(h)`, `ic_mean(h)`, `ic_std(h)`,
+      `icir(h)`, `rank_ic_mean(h)`, `rank_ic_std(h)` (``h`` defaults to 1)
     * **Reporting** — `config_report`
 
     Data-flow diagram

--- a/tests/benchmarks/test_basanos.py
+++ b/tests/benchmarks/test_basanos.py
@@ -397,19 +397,19 @@ class TestBasanosEngineBenchmarks:
 
     def test_ic_252_5(self, benchmark, engine_252_5):
         """Benchmark Pearson IC time series on 252-day, 5-asset engine."""
-        result = benchmark(lambda: engine_252_5.ic)
+        result = benchmark(lambda: engine_252_5.ic())
         assert "ic" in result.columns
         assert result.shape[0] == 251
 
     def test_rank_ic_252_5(self, benchmark, engine_252_5):
         """Benchmark Spearman Rank IC time series on 252-day, 5-asset engine."""
-        result = benchmark(lambda: engine_252_5.rank_ic)
+        result = benchmark(lambda: engine_252_5.rank_ic())
         assert "rank_ic" in result.columns
         assert result.shape[0] == 251
 
     def test_icir_252_5(self, benchmark, engine_252_5):
         """Benchmark ICIR (IC mean / IC std) on 252-day, 5-asset engine."""
-        result = benchmark(lambda: engine_252_5.icir)
+        result = benchmark(lambda: engine_252_5.icir())
         assert isinstance(result, float)
 
     def test_naive_sharpe_252_5(self, benchmark, engine_252_5):

--- a/tests/test_integration/test_engine_integration.py
+++ b/tests/test_integration/test_engine_integration.py
@@ -243,35 +243,35 @@ class TestSmoke:
 
     def test_ic_shape(self, engine: BasanosEngine) -> None:
         """Ic must have one row per timestamp except the last (no forward return available)."""
-        result = engine.ic
+        result = engine.ic()
         assert result.shape == (99, 2)
         assert "ic" in result.columns
 
     def test_rank_ic_shape(self, engine: BasanosEngine) -> None:
         """rank_ic must have one row per timestamp except the last."""
-        result = engine.rank_ic
+        result = engine.rank_ic()
         assert result.shape == (99, 2)
         assert "rank_ic" in result.columns
 
     def test_ic_mean_is_float(self, engine: BasanosEngine) -> None:
         """ic_mean must be a float scalar."""
-        assert isinstance(engine.ic_mean, float)
+        assert isinstance(engine.ic_mean(), float)
 
     def test_ic_std_is_float(self, engine: BasanosEngine) -> None:
         """ic_std must be a float scalar."""
-        assert isinstance(engine.ic_std, float)
+        assert isinstance(engine.ic_std(), float)
 
     def test_icir_is_float(self, engine: BasanosEngine) -> None:
         """Icir must be a float scalar."""
-        assert isinstance(engine.icir, float)
+        assert isinstance(engine.icir(), float)
 
     def test_rank_ic_mean_is_float(self, engine: BasanosEngine) -> None:
         """rank_ic_mean must be a float scalar."""
-        assert isinstance(engine.rank_ic_mean, float)
+        assert isinstance(engine.rank_ic_mean(), float)
 
     def test_rank_ic_std_is_float(self, engine: BasanosEngine) -> None:
         """rank_ic_std must be a float scalar."""
-        assert isinstance(engine.rank_ic_std, float)
+        assert isinstance(engine.rank_ic_std(), float)
 
     def test_naive_sharpe_is_float(self, engine: BasanosEngine) -> None:
         """naive_sharpe must be a float scalar."""

--- a/tests/test_math/test_end_to_end_notebook.py
+++ b/tests/test_math/test_end_to_end_notebook.py
@@ -240,28 +240,28 @@ class TestSignalQuality:
 
     def test_ic_mean_is_finite(self, notebook_engine: BasanosEngine) -> None:
         """IC mean must be a finite float."""
-        assert math.isfinite(notebook_engine.ic_mean)
+        assert math.isfinite(notebook_engine.ic_mean())
 
     def test_ic_std_is_positive_finite(self, notebook_engine: BasanosEngine) -> None:
         """IC std must be a finite positive float."""
-        assert math.isfinite(notebook_engine.ic_std)
-        assert notebook_engine.ic_std > 0
+        assert math.isfinite(notebook_engine.ic_std())
+        assert notebook_engine.ic_std() > 0
 
     def test_icir_is_finite(self, notebook_engine: BasanosEngine) -> None:
         """ICIR must be a finite float."""
-        assert math.isfinite(notebook_engine.icir)
+        assert math.isfinite(notebook_engine.icir())
 
     def test_rank_ic_mean_is_finite(self, notebook_engine: BasanosEngine) -> None:
         """Rank IC mean must be a finite float."""
-        assert math.isfinite(notebook_engine.rank_ic_mean)
+        assert math.isfinite(notebook_engine.rank_ic_mean())
 
     def test_ic_mean_concrete(self, notebook_engine: BasanosEngine) -> None:
         """IC mean must match the deterministic expected value (fixed seed 2024)."""
-        assert notebook_engine.ic_mean == pytest.approx(0.010676938245513712, rel=1e-4)
+        assert notebook_engine.ic_mean() == pytest.approx(0.010676938245513712, rel=1e-4)
 
     def test_icir_concrete(self, notebook_engine: BasanosEngine) -> None:
         """ICIR must match the deterministic expected value (fixed seed 2024)."""
-        assert notebook_engine.icir == pytest.approx(0.01920162208642282, rel=1e-4)
+        assert notebook_engine.icir() == pytest.approx(0.01920162208642282, rel=1e-4)
 
 
 # ─── NAV ──────────────────────────────────────────────────────────────────────

--- a/tests/test_math/test_optimizer.py
+++ b/tests/test_math/test_optimizer.py
@@ -1555,30 +1555,30 @@ class TestICTimeSeries:
 
     def test_ic_returns_polars_dataframe(self, ic_engine: BasanosEngine) -> None:
         """IC property must return a Polars DataFrame."""
-        assert isinstance(ic_engine.ic, pl.DataFrame)
+        assert isinstance(ic_engine.ic(), pl.DataFrame)
 
     def test_ic_has_expected_columns(self, ic_engine: BasanosEngine) -> None:
         """IC DataFrame must contain exactly 'date' and 'ic' columns."""
-        assert set(ic_engine.ic.columns) == {"date", "ic"}
+        assert set(ic_engine.ic().columns) == {"date", "ic"}
 
     def test_ic_length_is_t_minus_one(self, ic_engine: BasanosEngine, optimizer_prices: pl.DataFrame) -> None:
         """IC series must have T-1 rows (one per forward-return period)."""
-        assert ic_engine.ic.height == optimizer_prices.height - 1
+        assert ic_engine.ic().height == optimizer_prices.height - 1
 
     def test_ic_dates_match_signal_dates(self, ic_engine: BasanosEngine, optimizer_prices: pl.DataFrame) -> None:
         """Each IC date must equal the corresponding signal date (prices[t])."""
         expected_dates = optimizer_prices["date"].head(optimizer_prices.height - 1).to_list()
-        assert ic_engine.ic["date"].to_list() == expected_dates
+        assert ic_engine.ic()["date"].to_list() == expected_dates
 
     def test_ic_values_are_in_minus_one_to_one(self, ic_engine: BasanosEngine) -> None:
         """All finite IC values must lie in [-1, 1]."""
-        ic_vals = ic_engine.ic["ic"].drop_nulls().to_numpy()
+        ic_vals = ic_engine.ic()["ic"].drop_nulls().to_numpy()
         assert np.all(ic_vals >= -1.0 - 1e-12)
         assert np.all(ic_vals <= 1.0 + 1e-12)
 
     def test_ic_col_is_float64(self, ic_engine: BasanosEngine) -> None:
         """IC column must be Float64 dtype."""
-        assert ic_engine.ic["ic"].dtype == pl.Float64
+        assert ic_engine.ic()["ic"].dtype == pl.Float64
 
 
 class TestRankICTimeSeries:
@@ -1586,25 +1586,25 @@ class TestRankICTimeSeries:
 
     def test_rank_ic_returns_polars_dataframe(self, ic_engine: BasanosEngine) -> None:
         """rank_ic property must return a Polars DataFrame."""
-        assert isinstance(ic_engine.rank_ic, pl.DataFrame)
+        assert isinstance(ic_engine.rank_ic(), pl.DataFrame)
 
     def test_rank_ic_has_expected_columns(self, ic_engine: BasanosEngine) -> None:
         """rank_ic DataFrame must contain exactly 'date' and 'rank_ic' columns."""
-        assert set(ic_engine.rank_ic.columns) == {"date", "rank_ic"}
+        assert set(ic_engine.rank_ic().columns) == {"date", "rank_ic"}
 
     def test_rank_ic_length_is_t_minus_one(self, ic_engine: BasanosEngine, optimizer_prices: pl.DataFrame) -> None:
         """rank_ic series must have T-1 rows (one per forward-return period)."""
-        assert ic_engine.rank_ic.height == optimizer_prices.height - 1
+        assert ic_engine.rank_ic().height == optimizer_prices.height - 1
 
     def test_rank_ic_values_are_in_minus_one_to_one(self, ic_engine: BasanosEngine) -> None:
         """All finite Rank IC values must lie in [-1, 1]."""
-        vals = ic_engine.rank_ic["rank_ic"].drop_nulls().to_numpy()
+        vals = ic_engine.rank_ic()["rank_ic"].drop_nulls().to_numpy()
         assert np.all(vals >= -1.0 - 1e-12)
         assert np.all(vals <= 1.0 + 1e-12)
 
     def test_rank_ic_col_is_float64(self, ic_engine: BasanosEngine) -> None:
         """rank_ic column must be Float64 dtype."""
-        assert ic_engine.rank_ic["rank_ic"].dtype == pl.Float64
+        assert ic_engine.rank_ic()["rank_ic"].dtype == pl.Float64
 
 
 class TestICScalars:
@@ -1612,23 +1612,23 @@ class TestICScalars:
 
     def test_ic_mean_is_finite(self, ic_engine: BasanosEngine) -> None:
         """ic_mean must return a finite float for a well-behaved engine."""
-        assert math.isfinite(ic_engine.ic_mean)
+        assert math.isfinite(ic_engine.ic_mean())
 
     def test_ic_std_is_non_negative(self, ic_engine: BasanosEngine) -> None:
         """ic_std must be non-negative (standard deviation cannot be negative)."""
-        std = ic_engine.ic_std
+        std = ic_engine.ic_std()
         assert math.isfinite(std)
         assert std >= 0.0
 
     def test_icir_equals_mean_over_std(self, ic_engine: BasanosEngine) -> None:
         """ICIR must equal ic_mean / ic_std."""
-        mean = ic_engine.ic_mean
-        std = ic_engine.ic_std
+        mean = ic_engine.ic_mean()
+        std = ic_engine.ic_std()
         expected = mean / std if std != 0.0 else float("nan")
         if math.isnan(expected):
-            assert math.isnan(ic_engine.icir)
+            assert math.isnan(ic_engine.icir())
         else:
-            assert math.isclose(ic_engine.icir, expected, rel_tol=1e-12)
+            assert math.isclose(ic_engine.icir(), expected, rel_tol=1e-12)
 
     def test_icir_is_nan_when_std_is_zero(self) -> None:
         """ICIR must gracefully return a float (possibly NaN) in degenerate cases."""
@@ -1656,30 +1656,30 @@ class TestICScalars:
         eng = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
         # With all-zero signal, every ic row is NaN (corrcoef of constants).
         # icir should return NaN gracefully.
-        icir = eng.icir
+        icir = eng.icir()
         assert isinstance(icir, float)
 
     def test_rank_ic_mean_is_finite(self, ic_engine: BasanosEngine) -> None:
         """rank_ic_mean must return a finite float for a well-behaved engine."""
-        assert math.isfinite(ic_engine.rank_ic_mean)
+        assert math.isfinite(ic_engine.rank_ic_mean())
 
     def test_rank_ic_std_is_non_negative(self, ic_engine: BasanosEngine) -> None:
         """rank_ic_std must be non-negative."""
-        std = ic_engine.rank_ic_std
+        std = ic_engine.rank_ic_std()
         assert math.isfinite(std)
         assert std >= 0.0
 
     def test_ic_mean_matches_manual_computation(self, ic_engine: BasanosEngine) -> None:
         """ic_mean must equal np.nanmean of the ic series."""
-        ic_vals = ic_engine.ic["ic"].to_numpy()
+        ic_vals = ic_engine.ic()["ic"].to_numpy()
         expected = float(np.nanmean(ic_vals))
-        assert math.isclose(ic_engine.ic_mean, expected, rel_tol=1e-12)
+        assert math.isclose(ic_engine.ic_mean(), expected, rel_tol=1e-12)
 
     def test_rank_ic_mean_matches_manual_computation(self, ic_engine: BasanosEngine) -> None:
         """rank_ic_mean must equal np.nanmean of the rank_ic series."""
-        ric_vals = ic_engine.rank_ic["rank_ic"].to_numpy()
+        ric_vals = ic_engine.rank_ic()["rank_ic"].to_numpy()
         expected = float(np.nanmean(ric_vals))
-        assert math.isclose(ic_engine.rank_ic_mean, expected, rel_tol=1e-12)
+        assert math.isclose(ic_engine.rank_ic_mean(), expected, rel_tol=1e-12)
 
 
 class TestICNaNHandling:
@@ -1714,7 +1714,7 @@ class TestICNaNHandling:
         """IC must not raise and must return finite or NaN values for all rows."""
         cfg = BasanosConfig(vola=3, corr=5, clip=3.0, shrink=0.5, aum=1e6)
         eng = BasanosEngine(prices=nan_prices, mu=nan_mu, cfg=cfg)
-        ic_df = eng.ic
+        ic_df = eng.ic()
         assert ic_df.height == nan_prices.height - 1
         for v in ic_df["ic"].to_list():
             assert v is None or isinstance(v, float)
@@ -1744,10 +1744,99 @@ class TestICNaNHandling:
         )
         cfg = BasanosConfig(vola=2, corr=3, clip=3.0, shrink=0.5, aum=1e6)
         eng = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
-        ic_vals = eng.ic["ic"].to_list()
+        ic_vals = eng.ic()["ic"].to_list()
         # With only one valid asset pair, every IC value must be NaN
         for v in ic_vals:
             assert v is None or (isinstance(v, float) and math.isnan(v))
+
+
+class TestICHorizon:
+    """Tests for the forward-return horizon parameter ``h``."""
+
+    def test_h_default_matches_h1(self, ic_engine: BasanosEngine) -> None:
+        """ic() with no argument must match ic(h=1)."""
+        df_default = ic_engine.ic()
+        df_h1 = ic_engine.ic(h=1)
+        assert df_default.equals(df_h1)
+
+    def test_ic_h_greater_than_one_length(self, ic_engine: BasanosEngine, optimizer_prices: pl.DataFrame) -> None:
+        """ic(h=5) must have T - 5 rows."""
+        h = 5
+        df = ic_engine.ic(h=h)
+        assert df.height == optimizer_prices.height - h
+
+    def test_rank_ic_h_greater_than_one_length(self, ic_engine: BasanosEngine, optimizer_prices: pl.DataFrame) -> None:
+        """rank_ic(h=5) must have T - 5 rows."""
+        h = 5
+        df = ic_engine.rank_ic(h=h)
+        assert df.height == optimizer_prices.height - h
+
+    def test_ic_h_computes_correct_forward_returns(self, ic_engine: BasanosEngine) -> None:
+        """Verify that ic(h=3) uses prices[t+3]/prices[t]-1 as forward returns."""
+        h = 3
+        assets = ic_engine.assets
+        prices_np = ic_engine.prices.select(assets).to_numpy().astype(float)
+        mu_np = ic_engine.mu.select(assets).to_numpy().astype(float)
+
+        # Manually compute IC for t=0
+        fwd_ret = prices_np[h] / prices_np[0] - 1.0
+        signal = mu_np[0]
+        mask = np.isfinite(signal) & np.isfinite(fwd_ret)
+        expected_ic = float(np.corrcoef(signal[mask], fwd_ret[mask])[0, 1])
+
+        ic_df = ic_engine.ic(h=h)
+        actual_ic = ic_df["ic"][0]
+        assert math.isclose(actual_ic, expected_ic, rel_tol=1e-12)
+
+    def test_ic_h_greater_equal_t_gives_empty(self) -> None:
+        """When h >= T, IC must return an empty DataFrame."""
+        n = 5
+        start = date(2020, 1, 1)
+        dates = pl.date_range(start=start, end=start + timedelta(days=n - 1), interval="1d", eager=True)
+        prices = pl.DataFrame(
+            {
+                "date": dates,
+                "A": pl.Series([100.0, 102.0, 99.0, 103.0, 101.0], dtype=pl.Float64),
+                "B": pl.Series([200.0, 203.0, 198.0, 205.0, 201.0], dtype=pl.Float64),
+            }
+        )
+        mu = pl.DataFrame(
+            {
+                "date": dates,
+                "A": pl.Series([0.1, 0.2, 0.3, 0.4, 0.5], dtype=pl.Float64),
+                "B": pl.Series([0.5, 0.4, 0.3, 0.2, 0.1], dtype=pl.Float64),
+            }
+        )
+        cfg = BasanosConfig(vola=2, corr=3, clip=3.0, shrink=0.5, aum=1e6)
+        eng = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
+        df = eng.ic(h=n)
+        assert df.height == 0
+
+    def test_h_less_than_one_raises(self, ic_engine: BasanosEngine) -> None:
+        """H < 1 must raise ValueError."""
+        with pytest.raises(ValueError, match="h must be >= 1"):
+            ic_engine.ic(h=0)
+        with pytest.raises(ValueError, match="h must be >= 1"):
+            ic_engine.ic(h=-1)
+
+    def test_icir_with_horizon(self, ic_engine: BasanosEngine) -> None:
+        """icir(h) must thread h through to ic_mean(h) / ic_std(h)."""
+        h = 3
+        mean = ic_engine.ic_mean(h)
+        std = ic_engine.ic_std(h)
+        if std != 0.0 and np.isfinite(std):
+            expected = mean / std
+            assert math.isclose(ic_engine.icir(h), expected, rel_tol=1e-12)
+
+    def test_rank_ic_mean_with_horizon(self, ic_engine: BasanosEngine) -> None:
+        """rank_ic_mean(h=3) must be finite for a well-behaved engine."""
+        assert math.isfinite(ic_engine.rank_ic_mean(h=3))
+
+    def test_rank_ic_std_with_horizon(self, ic_engine: BasanosEngine) -> None:
+        """rank_ic_std(h=3) must be non-negative."""
+        std = ic_engine.rank_ic_std(h=3)
+        assert math.isfinite(std)
+        assert std >= 0.0
 
 
 # ─── sharpe_at_shrink and naive_sharpe ───────────────────────────────────────

--- a/tests/test_math/test_paper_example.py
+++ b/tests/test_math/test_paper_example.py
@@ -169,22 +169,22 @@ class TestPaperSignalQuality:
     """Verify ic, rank_ic, icir, and naive_sharpe from the paper listing."""
 
     def test_ic_is_dataframe(self, paper_engine: BasanosEngine) -> None:
-        assert isinstance(paper_engine.ic, pl.DataFrame)
+        assert isinstance(paper_engine.ic(), pl.DataFrame)
 
     def test_ic_height(self, paper_engine: BasanosEngine) -> None:
         assert paper_engine.prices.height == _N_DAYS
         assert paper_engine.mu.height == _N_DAYS
-        assert paper_engine.ic.height == _N_DAYS - 1  # no data for the last day!
+        assert paper_engine.ic().height == _N_DAYS - 1  # no data for the last day!
 
     def test_rank_ic_is_dataframe(self, paper_engine: BasanosEngine) -> None:
-        assert isinstance(paper_engine.rank_ic, pl.DataFrame)
+        assert isinstance(paper_engine.rank_ic(), pl.DataFrame)
 
     def test_rank_ic_height(self, paper_engine: BasanosEngine) -> None:
-        assert paper_engine.rank_ic.height == _N_DAYS - 1
+        assert paper_engine.rank_ic().height == _N_DAYS - 1
 
     def test_icir_is_finite_float(self, paper_engine: BasanosEngine) -> None:
-        assert isinstance(paper_engine.icir, float)
-        assert np.isfinite(paper_engine.icir)
+        assert isinstance(paper_engine.icir(), float)
+        assert np.isfinite(paper_engine.icir())
 
     def test_naive_sharpe_is_finite_float(self, paper_engine: BasanosEngine) -> None:
         assert isinstance(paper_engine.naive_sharpe, float)


### PR DESCRIPTION
Convert IC properties to methods accepting `h: int = 1` for multi-period forward-return evaluation. Default h=1 preserves existing behavior. Properties → methods is a breaking API change (e.g. `engine.ic` → `engine.ic()`).

## Description

<!-- Describe the changes introduced by this PR and the motivation behind them. -->

## Checklist

- [x] Tests added or updated
- [x] Docstrings updated for any new or changed public API
- [x] `CHANGELOG.md` entry added
- [x] `make fmt` has been run
