### PR TITLE
Fix: book build — configure mkdocstrings paths=[src] (no editable install)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,10 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
+          # src-layout: let griffe find the package by source path so the API
+          # docs build without installing basanos into the (uvx-isolated) book
+          # environment. Avoids needing `--with-editable .` in the book command.
+          paths: [src]
           options:
             docstring_style: google
             show_source: true


### PR DESCRIPTION
## Summary

After the v0.19.3 Rhiza sync (#555), the **book build broke**:

\`\`\`
mkdocstrings: accessing 'basanos' raises ModuleNotFoundError: No module named 'basanos'
PluginError: Could not collect 'basanos.BasanosError'
make: *** [.rhiza/make.d/book.mk:52: book] Error 1
\`\`\`

### Root cause

The sync dropped \`--with-editable .\` from \`MKDOCS_EXTRA_PACKAGES\` because the Rhiza smoke test \`test_default_book_command_does_not_use_editable_install\` forbids it. The book's API reference is generated by **mkdocstrings**, which then could no longer import the **src-layout** \`basanos\` package from the \`uvx\`-isolated build environment — the editable install was the only thing making it importable.

### Fix

Set \`paths: [src]\` on the mkdocstrings python handler in \`mkdocs.yml\`. This is the canonical src-layout configuration: griffe resolves the package by **source path** (static analysis, no import/install needed). Satisfies both constraints — the book builds **and** the no-editable-install smoke test stays green.

### Verification

- \`uvx --with 'mkdocstrings[python]' zensical build\` → **exit 0**, no \`Could not collect\` errors; \`_book/api/exceptions/index.html\` documents \`BasanosError\` and friends (37 symbol references).
- \`.rhiza/tests/integration/test_docs_targets.py\` → **3 passed** (including the no-editable-install assertion).
- Only \`mkdocs.yml\` changed; build artifacts are gitignored.

> Note: the marimo-notebook \`ImportError: _DEFAULT_COND_THRESHOLD\` reported earlier was a separate cvx-linalg API rename, already fixed in #555 (version-robust import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)