### PR TITLE
feat: add ClusterFuzzLite fuzzing scaffold for basanos

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,9 @@
+# ClusterFuzzLite build image for basanos.
+# Uses the OSS-Fuzz Python base image, which provides Atheris and the
+# compile_python_fuzzer helper.
+# Pinned by SHA256 so the build image only changes through reviewed updates.
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:99c714c91ec30778a3ce3ae5b37491a81fc043808bc8f2955159c2f608f80116
+
+COPY . $SRC
+WORKDIR $SRC
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# ClusterFuzzLite build script — installs basanos and compiles each Python
+# harness in tests/fuzz/ via OSS-Fuzz's compile_python_fuzzer helper.
+
+cd "$SRC"
+
+# Pin pip so the build environment is reproducible and only changes through a
+# reviewed bump (the same rationale as the SHA-pinned base image).
+pip3 install --upgrade "pip==24.3.1"
+
+# Install the package and its runtime dependencies (numpy, scipy, polars,
+# pydantic, jquantstats, ...) so PyInstaller can discover and bundle basanos
+# into each frozen fuzzer binary.
+pip3 install .
+
+# PyInstaller does not discover the compiled extension modules of numpy/scipy on
+# their own, so the frozen fuzzer crashes at runtime (numpy: "No module named
+# 'numpy._core._exceptions'"; scipy: "extension modules cannot be imported").
+# --collect-all pulls in every submodule, data file and shared library for both.
+# polars/pydantic are bundled via the static import graph.
+for fuzzer in tests/fuzz/fuzz_*.py; do
+  compile_python_fuzzer "$fuzzer" --collect-all numpy --collect-all scipy
+done

--- a/tests/fuzz/fuzz_signal.py
+++ b/tests/fuzz/fuzz_signal.py
@@ -1,0 +1,59 @@
+"""Fuzz the basanos matrix-shrinkage helper against arbitrary matrices.
+
+``shrink2id`` shrinks a square numpy matrix toward the identity by a weight
+factor and must never crash with an unexpected exception on adversarial input
+(degenerate shapes, non-finite values). This harness exercises that contract
+with coverage-guided input.
+
+Run locally:
+    pip install atheris numpy scipy polars pydantic
+    python tests/fuzz/fuzz_signal.py -atheris_runs=20000
+
+Run in ClusterFuzzLite: this file is built by .clusterfuzzlite/build.sh.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+
+import atheris
+
+# Pre-import the heavy native dependencies OUTSIDE the instrumentation block.
+# Atheris's import hook miscompiles parts of polars' (and other Rust/C
+# extensions') Python machinery, so we let them load uninstrumented and
+# instrument only the first-party package under test. Importing
+# basanos.math._signal pulls in the whole basanos.math package, whose __init__
+# imports these libraries, so they must be cached uninstrumented beforehand.
+import numpy as np
+import plotly.graph_objects  # pre-imported uninstrumented
+import plotly.io  # noqa: F401  # pre-imported uninstrumented
+import polars as pl  # noqa: F401  # pre-imported uninstrumented
+import pydantic  # noqa: F401  # pre-imported uninstrumented
+import scipy.signal  # pre-imported uninstrumented
+import scipy.stats  # noqa: F401  # pre-imported uninstrumented
+
+with atheris.instrument_imports():
+    from basanos.math._signal import shrink2id
+
+_ALLOWED = (ValueError, TypeError, ZeroDivisionError, np.linalg.LinAlgError)
+
+
+def test_one_input(data: bytes) -> None:
+    """Shrink a fuzzed square matrix toward the identity."""
+    fdp = atheris.FuzzedDataProvider(data)
+    n = fdp.ConsumeIntInRange(0, 8)
+    matrix = np.array([fdp.ConsumeFloat() for _ in range(n * n)], dtype=np.float64).reshape(n, n)
+
+    with contextlib.suppress(_ALLOWED):
+        shrink2id(matrix, fdp.ConsumeProbability())
+
+
+def main() -> None:
+    """Run the Atheris fuzz loop."""
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the opt-in **ClusterFuzzLite** fuzzing scaffold so the existing `rhiza_fuzzing.yml` workflow actually runs.

- `.clusterfuzzlite/Dockerfile` — OSS-Fuzz Python base image, SHA-pinned
- `.clusterfuzzlite/build.sh` — installs the package and compiles each `tests/fuzz/fuzz_*.py` harness
- `tests/fuzz/fuzz_signal.py` — fuzzes `basanos.math` `shrink2id()` with arbitrary matrices. Heavy native deps (numpy/scipy/polars/pydantic/plotly) pre-imported outside `instrument_imports()`; `--collect-all numpy --collect-all scipy`.

`FUZZING_ENABLED` is already set to `true`.

## Test plan
- [x] Build verified locally against the OSS-Fuzz `base-builder-python` image (basanos modules, pydantic_core and scipy all bundled)
- [ ] Runtime fuzz loop on CI (cannot run locally: polars' Rust binary SIGILLs under x86-on-arm64 emulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
