### PR TITLE
fix(deps): support cvx-linalg 0.9+/1.0 module layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Correlation-aware portfolio optimization and analytics for Python
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "cvx-linalg>=0.6.1",
+    "cvx-linalg>=0.9.0",
     "jinja2>=3",
     "jquantstats>=0.9",
     "numpy>=2.4",

--- a/src/basanos/math/_stream.py
+++ b/src/basanos/math/_stream.py
@@ -39,7 +39,7 @@ from typing import Any, cast
 import numpy as np
 import polars as pl
 from cvx.linalg import cov_to_corr
-from cvx.linalg.ewm_cov import ewm_covariance
+from cvx.linalg.covariance.ewm_cov import ewm_covariance
 from scipy.signal import lfilter
 
 from ..exceptions import MissingDateColumnError, StreamStateCorruptError

--- a/src/basanos/math/optimizer.py
+++ b/src/basanos/math/optimizer.py
@@ -85,7 +85,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import polars as pl
 from cvx.linalg import cov_to_corr
-from cvx.linalg.ewm_cov import ewm_covariance
+from cvx.linalg.covariance.ewm_cov import ewm_covariance
 from jquantstats import Portfolio
 
 from ..exceptions import (

--- a/tests/test_math/test_ewm_covariance.py
+++ b/tests/test_math/test_ewm_covariance.py
@@ -27,7 +27,7 @@ import numpy as np
 import pandas as pd
 import polars as pl
 import pytest
-from cvx.linalg.ewm_cov import ewm_covariance
+from cvx.linalg.covariance.ewm_cov import ewm_covariance
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 

--- a/tests/test_math/test_factor_model.py
+++ b/tests/test_math/test_factor_model.py
@@ -17,10 +17,13 @@ import numpy as np
 import pytest
 from cvx.linalg import DimensionMismatchError, IllConditionedMatrixWarning, SingularMatrixError
 
-try:  # cvx-linalg >= 0.7 renamed this constant from the private to the public name
-    from cvx.linalg.solve import DEFAULT_COND_THRESHOLD as _DEFAULT_COND_THRESHOLD  # type: ignore[attr-defined]
-except ImportError:  # older cvx-linalg only exposes the private name
-    from cvx.linalg.solve import _DEFAULT_COND_THRESHOLD
+try:  # cvx-linalg >= 1.0 re-exports the public constant at the package root
+    from cvx.linalg import DEFAULT_COND_THRESHOLD as _DEFAULT_COND_THRESHOLD
+except ImportError:
+    try:  # cvx-linalg >= 0.7 exposed the public name under .solve
+        from cvx.linalg.solve import DEFAULT_COND_THRESHOLD as _DEFAULT_COND_THRESHOLD  # type: ignore[attr-defined]
+    except ImportError:  # older cvx-linalg only exposes the private name
+        from cvx.linalg.solve import _DEFAULT_COND_THRESHOLD
 
 from basanos.exceptions import FactorModelError
 from basanos.math._factor_model import FactorModel

--- a/tests/test_math/test_numerical_stability.py
+++ b/tests/test_math/test_numerical_stability.py
@@ -29,10 +29,13 @@ import polars as pl
 import pytest
 from cvx.linalg import IllConditionedMatrixWarning, solve
 
-try:  # cvx-linalg >= 0.7 renamed this constant from the private to the public name
-    from cvx.linalg.solve import DEFAULT_COND_THRESHOLD as _DEFAULT_COND_THRESHOLD  # type: ignore[attr-defined]
-except ImportError:  # older cvx-linalg only exposes the private name
-    from cvx.linalg.solve import _DEFAULT_COND_THRESHOLD
+try:  # cvx-linalg >= 1.0 re-exports the public constant at the package root
+    from cvx.linalg import DEFAULT_COND_THRESHOLD as _DEFAULT_COND_THRESHOLD
+except ImportError:
+    try:  # cvx-linalg >= 0.7 exposed the public name under .solve
+        from cvx.linalg.solve import DEFAULT_COND_THRESHOLD as _DEFAULT_COND_THRESHOLD  # type: ignore[attr-defined]
+    except ImportError:  # older cvx-linalg only exposes the private name
+        from cvx.linalg.solve import _DEFAULT_COND_THRESHOLD
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from hypothesis.extra import numpy as np_st

--- a/uv.lock
+++ b/uv.lock
@@ -68,7 +68,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cvx-linalg", specifier = ">=0.6.1" },
+    { name = "cvx-linalg", specifier = ">=0.9.0" },
     { name = "jinja2", specifier = ">=3" },
     { name = "jquantstats", specifier = ">=0.9" },
     { name = "numpy", specifier = ">=2.4" },
@@ -303,14 +303,14 @@ toml = [
 
 [[package]]
 name = "cvx-linalg"
-version = "0.8.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/a0/a1c198e4e01bf1eb2e61bdc81943be7fe80aad5c1fdff2504bf209505503/cvx_linalg-0.8.0.tar.gz", hash = "sha256:38533d446b88300c7dd776efee10105fce293e5a51819f9c42be38bbc8352ed8", size = 25520, upload-time = "2026-06-16T14:25:31.41Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/80/06c3d348fc0665de348888d14f2134c210b0720fc5d0e24b3da41f5052c7/cvx_linalg-1.0.0.tar.gz", hash = "sha256:c3626155679434344bbe1a765db7c16c943f4f424ef1ee34e7b464f32fdb570a", size = 41122, upload-time = "2026-07-07T04:32:50.891Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/1a/13c31e88049fb033d3e858ba94e6d0a5aff812aff4f5857e29105efc18b8/cvx_linalg-0.8.0-py3-none-any.whl", hash = "sha256:8c2fc777037eb26ec30b5dc242ddfc05663a8d78f85e96180acd25a0a9cea61a", size = 28527, upload-time = "2026-06-16T14:25:30.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7f/e8ae0b18c421c53ab7c47e982b2aeda8f80844240b82e7118a5d5192f5c0/cvx_linalg-1.0.0-py3-none-any.whl", hash = "sha256:b59231d1bc7db260986e9527e9c2aa2c2f374259f135b8463353c6bd515eecf9", size = 51349, upload-time = "2026-07-07T04:32:49.601Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

CI was failing wherever the newer `cvx-linalg` was resolved (the `WEEKLY` latest-deps job and dependabot PR #568):

```
ModuleNotFoundError: No module named 'cvx.linalg.ewm_cov'
```

`cvx-linalg` restructured its package:
- **0.9.0** moved `ewm_covariance` from `cvx.linalg.ewm_cov` → `cvx.linalg.covariance.ewm_cov`.
- **1.0.0** re-exports `DEFAULT_COND_THRESHOLD` at the package root (`cvx.linalg`) rather than under `cvx.linalg.solve`.

The failed import cascaded into the doctests for `basanos.math._config` and `basanos.math._engine_solve` (the `NameError`s in the CI log were downstream of the failed `import`).

## Fix

- Update the three `ewm_covariance` imports (`optimizer.py`, `_stream.py`, `test_ewm_covariance.py`) to the new `cvx.linalg.covariance.ewm_cov` path. The function signature is unchanged, so all call sites are untouched.
- Make the `DEFAULT_COND_THRESHOLD` fallback in the two test modules try the 1.0 package-root export first, then the older `.solve` locations.
- Bump the floor to `cvx-linalg>=0.9.0` (the version that introduced the new layout) and relock — resolves to **1.0.0**.

## Verification

- `708 passed` (full functional suite; the benchmark errors are a local missing-`pytest-benchmark` env, not this change).
- Doctests across `src/basanos` pass (39 passed), including the two modules CI flagged.
- `ruff check` clean.

This supersedes the `cvx-linalg` portion of #568 by also fixing the code, not just the lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)