### PR TITLE
refactor(math): reduce complexity, untangle config/report cycle, drop dead cvx fallback

### DIFF
--- a/src/basanos/math/_config.py
+++ b/src/basanos/math/_config.py
@@ -7,7 +7,7 @@ unaffected.
 
 import enum
 import logging
-from typing import TYPE_CHECKING, Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal, TypeVar
 
 from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
@@ -24,6 +24,19 @@ class _SentinelType:
 
 
 _SENTINEL = _SentinelType()
+
+_T = TypeVar("_T")
+
+
+def _coalesce(override: _T | None, current: _T) -> _T:
+    """Return *override* when it is not ``None``, otherwise *current*.
+
+    Helper for `BasanosConfig.replace`: a ``None`` override means
+    "keep the existing value". Factoring the per-field ``x if x is None
+    else y`` choice into a named call keeps `replace` flat rather than a
+    long ternary chain.
+    """
+    return current if override is None else override
 
 
 class CovarianceMode(enum.StrEnum):
@@ -530,17 +543,17 @@ class BasanosConfig(BaseModel):
         """
         new_max_turnover: float | None = self.max_turnover if isinstance(max_turnover, _SentinelType) else max_turnover
         return BasanosConfig(
-            vola=self.vola if vola is None else vola,
-            corr=self.corr if corr is None else corr,
-            clip=self.clip if clip is None else clip,
-            shrink=self.shrink if shrink is None else shrink,
-            aum=self.aum if aum is None else aum,
-            denom_tol=self.denom_tol if denom_tol is None else denom_tol,
-            position_scale=self.position_scale if position_scale is None else position_scale,
-            min_corr_denom=self.min_corr_denom if min_corr_denom is None else min_corr_denom,
-            max_nan_fraction=self.max_nan_fraction if max_nan_fraction is None else max_nan_fraction,
-            covariance_config=self.covariance_config if covariance_config is None else covariance_config,
-            cost_per_unit=self.cost_per_unit if cost_per_unit is None else cost_per_unit,
+            vola=_coalesce(vola, self.vola),
+            corr=_coalesce(corr, self.corr),
+            clip=_coalesce(clip, self.clip),
+            shrink=_coalesce(shrink, self.shrink),
+            aum=_coalesce(aum, self.aum),
+            denom_tol=_coalesce(denom_tol, self.denom_tol),
+            position_scale=_coalesce(position_scale, self.position_scale),
+            min_corr_denom=_coalesce(min_corr_denom, self.min_corr_denom),
+            max_nan_fraction=_coalesce(max_nan_fraction, self.max_nan_fraction),
+            covariance_config=_coalesce(covariance_config, self.covariance_config),
+            cost_per_unit=_coalesce(cost_per_unit, self.cost_per_unit),
             max_turnover=new_max_turnover,
         )
 
@@ -587,6 +600,11 @@ class BasanosConfig(BaseModel):
             >>> "Parameters" in html
             True
         """
+        # Lazy import by design: `_config` is the lowest layer and
+        # `_config_report` (the rendering layer) imports `BasanosConfig` from
+        # here at module load. Importing it eagerly would invert that edge and
+        # reintroduce a cycle; deferring keeps the module-level graph acyclic
+        # while still offering the `.report` accessor (cf. pandas' `.plot`).
         from ._config_report import ConfigReport
 
         return ConfigReport(config=self)

--- a/src/basanos/math/_config_report.py
+++ b/src/basanos/math/_config_report.py
@@ -24,8 +24,14 @@ import plotly.graph_objects as go
 import plotly.io as pio
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
+# BasanosConfig lives in the lower-layer `_config` module; import it directly
+# rather than via `optimizer` (which re-exports it) so this rendering layer
+# never depends on the composition root. BasanosEngine is only ever referenced
+# as a type hint, so it stays under TYPE_CHECKING and creates no runtime edge.
+from ._config import BasanosConfig
+
 if TYPE_CHECKING:
-    from .optimizer import BasanosConfig, BasanosEngine
+    from .optimizer import BasanosEngine
 
 _TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
 _env = Environment(
@@ -37,20 +43,21 @@ _env = Environment(
 # ── Parameter metadata ────────────────────────────────────────────────────────
 
 
+# Pydantic v2 constraint attributes on a metadata object, paired with the
+# comparison symbol used to render them.
+_CONSTRAINT_SYMBOLS = (("gt", ">"), ("ge", "≥"), ("lt", "<"), ("le", "≤"))
+
+
 def _constraint_str(field_info: object) -> str:
     """Extract a compact constraint string from a pydantic FieldInfo."""
     parts: list[str] = []
     # Pydantic v2 stores constraints inside field_info.metadata
     metadata = getattr(field_info, "metadata", [])
     for m in metadata:
-        if hasattr(m, "gt") and m.gt is not None:
-            parts.append(f"> {m.gt}")
-        if hasattr(m, "ge") and m.ge is not None:
-            parts.append(f"≥ {m.ge}")
-        if hasattr(m, "lt") and m.lt is not None:
-            parts.append(f"< {m.lt}")
-        if hasattr(m, "le") and m.le is not None:
-            parts.append(f"≤ {m.le}")
+        for attr, symbol in _CONSTRAINT_SYMBOLS:
+            bound = getattr(m, attr, None)
+            if bound is not None:
+                parts.append(f"{symbol} {bound}")
     return ", ".join(parts) if parts else "—"
 
 
@@ -74,8 +81,6 @@ def _params_table_html(config: BasanosConfig) -> str:
     Returns:
         An HTML ``<table>`` string ready to embed in a page.
     """
-    from .optimizer import BasanosConfig  # local import to avoid circularity
-
     rows: list[str] = []
     for name, field_info in BasanosConfig.model_fields.items():
         value = getattr(config, name)

--- a/src/basanos/math/_factor_model.py
+++ b/src/basanos/math/_factor_model.py
@@ -17,17 +17,15 @@ import dataclasses
 from typing import cast
 
 import numpy as np
+
+# cvx-linalg exposes this constant as a public top-level name since >= 0.7;
+# the project floor is cvx-linalg>=0.9.0 (see pyproject.toml), so the public
+# import always resolves and no legacy-layout fallback is required.
+from cvx.linalg import DEFAULT_COND_THRESHOLD as _DEFAULT_COND_THRESHOLD
 from cvx.linalg import DimensionMismatchError, SingularMatrixError
 from cvx.linalg import check_and_warn_condition as _check_and_warn_condition
 from cvx.linalg import inv as _inv
 from cvx.linalg import solve as _solve
-
-try:  # cvx-linalg >= 0.7 exposes this constant as a public top-level name
-    from cvx.linalg import DEFAULT_COND_THRESHOLD as _DEFAULT_COND_THRESHOLD
-except ImportError:  # older cvx-linalg only exposes the private name
-    from cvx.linalg.solve import (  # type: ignore[attr-defined,no-redef]
-        _DEFAULT_COND_THRESHOLD,  # ty: ignore[unresolved-import]
-    )
 
 from basanos.exceptions import FactorModelError
 

--- a/src/basanos/math/optimizer.py
+++ b/src/basanos/math/optimizer.py
@@ -80,7 +80,6 @@ readable and independently testable:
 import dataclasses
 import datetime
 import logging
-from typing import TYPE_CHECKING
 
 import numpy as np
 import polars as pl
@@ -103,13 +102,11 @@ from ._config import (
     EwmaShrinkConfig,
     SlidingWindowConfig,
 )
+from ._config_report import ConfigReport
 from ._engine_diagnostics import _DiagnosticsMixin as _DiagnosticsMixin
 from ._engine_ic import _SignalEvaluatorMixin as _SignalEvaluatorMixin
 from ._engine_solve import _SolveMixin as _SolveMixin
 from ._signal import vol_adj
-
-if TYPE_CHECKING:
-    from ._config_report import ConfigReport
 
 _logger = logging.getLogger(__name__)
 
@@ -771,8 +768,6 @@ class BasanosEngine(_DiagnosticsMixin, _SignalEvaluatorMixin, _SolveMixin):
             >>> "Lambda" in html
             True
         """
-        from ._config_report import ConfigReport
-
         return ConfigReport(config=self.cfg, engine=self)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses three of the four rhiza v1.1.1 quality-scorecard findings (all `src/`-local, no template changes).

| Issue | Subcategory | Before → After |
|-------|-------------|----------------|
| #571 | Code complexity | `BasanosConfig.replace` CC **13 → 2**, `_constraint_str` CC **11 → 5**; no C-or-worse blocks remain |
| #572 | Architecture | 3 runtime function-local imports → **1** (documented facade); module-level import graph now **acyclic** |
| #573 | Test coverage | dead cvx-linalg fallback removed; `_factor_model.py` **97% → 100%**, total src **99.83% → 100%** |

## Changes

**#571 — complexity**
- Extract a module-level `_coalesce(override, current)` helper; `BasanosConfig.replace` becomes a flat forwarding call instead of a 12-ternary chain.
- Make `_constraint_str` iterate a `(attr, symbol)` table instead of four `hasattr … is not None` branches.

**#572 — import cycle**
- `BasanosConfig` lives in the lower-layer `_config`, but `_config_report` was importing it *via `optimizer`* (which merely re-exports it). Now imported directly from `._config` at module level; `BasanosEngine` (type-only) stays under `TYPE_CHECKING`.
- `optimizer` imports `ConfigReport` at module level (its function-local import is gone), since `_config_report` no longer reaches back into `optimizer` at runtime.
- The one remaining lazy import — `BasanosConfig.report` → `ConfigReport` — is the intentional leaf→renderer facade (à la pandas `.plot`); importing it eagerly would re-invert the edge. Documented in place.

**#573 — dead fallback**
- The public `cvx.linalg.DEFAULT_COND_THRESHOLD` exists since `>=0.7`; the project floor is `cvx-linalg>=0.9.0`, so the `except ImportError` branch was unreachable — and its target `cvx.linalg.solve._DEFAULT_COND_THRESHOLD` no longer exists in 1.0.0. Removed the try/except in favour of the direct import.

## Not included — #574 (test design)
Investigated and found **already satisfied**: each of the five `test_*_notebook.py` files already pairs one `test_notebook_executes` smoke test with 14–37 granular "mirror" tests carrying 13–42 targeted assertions (assets, row counts, finiteness, concrete Sharpe/IC/turnover values). Subprocess-based execution was already removed in #529. Recommend closing #574 as already-addressed. See the issue for details.

## Quality gates

| Gate | Result |
|------|--------|
| `make fmt` | ✅ PASS |
| `make typecheck` (ty + mypy --strict) | ✅ PASS |
| `make docs-coverage` | ✅ PASS (100%) |
| `make deptry` | ✅ PASS |
| `make security` | ✅ PASS |
| `make validate` | ✅ PASS |
| `make test` | ✅ PASS (708 passed, **100.00%** coverage) |

Closes #571
Closes #572
Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)
