### PR TITLE
chore: update rhiza to v1.2.1

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.2.1
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.2.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.2.1
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.2.1
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.2.1
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.2.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.2.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -222,7 +222,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.0
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.1
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,11 +1,16 @@
-sha: 7a906d2cf8c33d1d870ca7c7f5af3127f070c3ed
+sha: e0fe02300840e39fe75d19db2741e9a790f87794
 repo: jebel-quant/rhiza
 host: github
-ref: v1.2.0
+ref: v1.2.1
 include: []
-exclude: []
+exclude:
+- bundles/github/.github/workflows/rhiza_fuzzing.yml
+- bundles/github/.github/workflows/rhiza_weekly.yml
+- bundles/github/.github/workflows/rhiza_scorecard.yml
 templates:
 - legal
+profiles:
+- github-project
 files:
 - .bandit
 - .editorconfig
@@ -25,12 +30,9 @@ files:
 - .github/workflows/rhiza_book.yml
 - .github/workflows/rhiza_ci.yml
 - .github/workflows/rhiza_codeql.yml
-- .github/workflows/rhiza_fuzzing.yml
 - .github/workflows/rhiza_marimo.yml
 - .github/workflows/rhiza_mutation.yml
 - .github/workflows/rhiza_release.yml
-- .github/workflows/rhiza_scorecard.yml
-- .github/workflows/rhiza_weekly.yml
 - .gitignore
 - .pre-commit-config.yaml
 - .python-version
@@ -72,7 +74,5 @@ files:
 - docs/mkdocs-base.yml
 - pytest.ini
 - ruff.toml
-profiles:
-- github-project
-synced_at: '2026-07-16T14:09:35Z'
+synced_at: '2026-07-17T12:43:55Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: jebel-quant/rhiza
-ref: "v1.2.0"
+ref: "v1.2.1"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Summary
- Bumps the template `ref` to `v1.2.1` in `.rhiza/template.yml` (from `v1.2.0`)
- Platform profile: `github-project` (unchanged; matches the GitHub origin)
- Runs the bundled `scripts/sync.py` to apply upstream template changes; the 7 workflow conflicts were resolved taking the upstream side (all were the `uses: …@v1.2.0` → `@v1.2.1` ref bump)

## Quality gates

| Gate | Result |
|------|--------|
| `make fmt` (lint/format/pre-commit) | ✅ PASS |
| `make typecheck` (ty + mypy --strict) | ✅ PASS |
| `make docs-coverage` (interrogate) | ✅ PASS (100%, min 100%) |
| `make deptry` (dependency hygiene) | ✅ PASS |
| `make security` (bandit) | ✅ PASS |
| `make validate` | ⚪ N/A (no such target in this downstream repo) |
| `make test` (suite + coverage gate) | ✅ PASS (708 passed, 100% coverage, gate 90%) |
| test-layout parity (`check_test_layout.py`) | ❌ FAIL (structural — see scorecard) |

## Scorecard (locally-owned scope)

| Subcategory | Score | Notes |
|-------------|:-----:|-------|
| Linting / style | 10 | `make fmt` fully clean |
| Type safety | 10 | `ty` + `mypy --strict` clean over 20 modules |
| Docstring / API-doc coverage | 10 | interrogate 100% (gate 100%) |
| Test pass rate | 10 | 708/708 passing |
| Test coverage & depth | 10 | 100% line coverage; property, notebook, edge-case & regression suites |
| Dependency & security hygiene | 10 | deptry clean, bandit clean |
| Code complexity | 9 | radon avg **A** (2.63), no C-or-worse blocks, all modules MI grade A; `optimizer.py` (786 LOC) is the only oversized module |
| Overall architecture | 9 | Clean layering (`_config`/`exceptions` base → `_engine_*`/`_factor_model` → `_stream_*` → `_stream`), mixin composition, no import cycles; `math/` is a large package |
| Test-layout parity | 5 | Tests are organized by behaviour (`tests/test_math/…`, notebook/property suites) rather than the 1:1 `tests/<pkg>/test_<name>.py` mirror the bundled checker enforces |
| Template fidelity (`make validate`) | ⚪ | out-of-scope / upstream (no target downstream) |

**Overall: 9/10.** Excellent code quality, types, docs, and test coverage. The single blemish is test-layout parity against the rhiza checker's 1:1 mirror expectation.

**Highest-leverage improvement:** reconcile test-layout parity — either migrate to the mirrored `tests/<pkg>/test_<name>.py` layout or configure/exempt the checker to accept the behaviour-grouped structure.

## Recommendations (ordered by leverage)
1. **Reconcile test-layout parity** (test-layout 5→10) — `tests/` vs `src/basanos/`. Done when `check_test_layout.py` exits 0 (mirror the layout, or record the intentional grouping in the checker config).
2. **Split `optimizer.py`** (complexity 9→10) — `src/basanos/math/optimizer.py` is 786 LOC. Done when no `src/` module exceeds ~500 LOC and radon MI stays grade A.
