### PR TITLE
chore: address quality-scorecard issues (#585, #586, #587, #588)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,17 @@ MKDOCS_EXTRA_PACKAGES = --with 'mkdocstrings[python]'
 # Always include the Rhiza API (template-managed)
 include .rhiza/rhiza.mk
 
+# Test-layout parity: basanos groups tests by behaviour rather than mirroring
+# the source tree 1:1, so a bespoke checker enforces the two properties that
+# matter (every public module is tested; every test traces back to code) with
+# the intentional behaviour-grouping recorded as configuration. Chained onto
+# the CI `test` job (a double-colon rule) so a drift fails CI, not just review.
+.PHONY: test-layout
+test-layout: ## check public modules are tested and tests trace back to code
+	@printf "${BLUE}[INFO] Checking test-layout parity${RESET}\n"
+	@$(UV_BIN) run python scripts/check_test_layout.py
+
+test:: test-layout
+
 # Optional: developer-local extensions (not committed)
 -include local.mk

--- a/scripts/check_test_layout.py
+++ b/scripts/check_test_layout.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Check that public source modules are tested and tests trace back to code.
+
+basanos organises its tests by *behaviour* rather than mirroring the source
+tree one-to-one: a single source module is often exercised by several suites
+(e.g. ``optimizer.py`` is covered by ``test_optimizer.py``,
+``test_optimizer_property.py`` and ``test_optimizer_edge_cases.py``), and
+whole-pipeline suites (the ``*_notebook`` end-to-end tests, numerical
+regression/stability suites, the paper-example walkthrough) span many modules
+and map to no single source file. A strict ``tests/<pkg>/test_<name>.py`` ↔
+``src/<pkg>/<name>.py`` mirror is therefore the wrong shape for this repo.
+
+This checker enforces the two properties that actually matter here, while
+recording the intentional behaviour-grouping as configuration:
+
+  * **Every public source module is tested.** For each non-underscore module
+    under ``src/`` (private ``_*`` modules and ``__init__`` are skipped), a
+    ``test_<name>.py`` file must exist *somewhere* under ``tests/`` — the
+    behaviour grouping decides where.
+  * **Every test traces back to real code.** Each ``tests/**/test_*.py`` file
+    must either name a real source module (``<name>.py`` or ``_<name>.py``
+    anywhere under ``src/``) or be a declared cross-cutting suite (see
+    :data:`ALLOWED_ORPHANS` / :data:`ORPHAN_SUFFIXES`).
+
+``__init__.py``/``conftest.py`` and the ``tests/benchmarks/`` and
+``tests/stress/`` trees are exempt. Test *functions* and *classes* are
+unconstrained.
+
+Usage:
+  python3 scripts/check_test_layout.py
+
+Exits 0 when the layout is clean, 1 (listing every violation) otherwise.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+SRC_ROOT = ROOT / "src"
+TEST_ROOT = ROOT / "tests"
+
+_IGNORED = {"__init__.py", "conftest.py"}
+
+# Top-level directories under tests/ that need not trace back to a source
+# module (benchmarks and load/stress suites).
+_EXEMPT_DIRS = {"benchmarks", "stress"}
+
+# Cross-cutting test suites that intentionally map to no single source module.
+# ``test_<stem>.py`` files whose stem is listed here (or matches one of
+# ``ORPHAN_SUFFIXES``) are recognised as behaviour suites, not orphans.
+ALLOWED_ORPHANS: frozenset[str] = frozenset(
+    {
+        "cross_mode_consistency",  # EWMA vs sliding-window path agreement
+        "engine_integration",  # end-to-end engine wiring
+        "ewm_covariance",  # EWMA covariance behaviour
+        "numerical_regression",  # pinned numerical outputs
+        "numerical_stability",  # degenerate-input robustness
+        "paper_example",  # reproduces the reference paper example
+        "shim",  # analytics compatibility shim
+    }
+)
+
+# Suffixes marking a whole family of behaviour suites (kept as patterns so new
+# suites in these families need no extra configuration).
+ORPHAN_SUFFIXES: tuple[str, ...] = ("_notebook", "_property", "_edge_cases")
+
+
+def _public_source_modules() -> list[Path]:
+    """Return public (non-underscore, non-dunder) ``.py`` modules under src/."""
+    return sorted(p for p in SRC_ROOT.rglob("*.py") if p.name not in _IGNORED and not p.name.startswith("_"))
+
+
+def _source_basenames() -> set[str]:
+    """Return every source module basename, with any leading underscore stripped.
+
+    ``src/basanos/math/_signal.py`` and ``src/basanos/math/optimizer.py`` both
+    contribute (``signal``, ``optimizer``), so a ``test_signal.py`` covering a
+    private module is not reported as an orphan.
+    """
+    names: set[str] = set()
+    for p in SRC_ROOT.rglob("*.py"):
+        if p.name in _IGNORED:
+            continue
+        names.add(p.stem.lstrip("_"))
+    return names
+
+
+def _test_files() -> list[Path]:
+    """Return ``test_*.py`` files under tests/ (ignoring conftest/exempt dirs)."""
+    return sorted(
+        p
+        for p in TEST_ROOT.rglob("test_*.py")
+        if p.name not in _IGNORED and p.relative_to(TEST_ROOT).parts[0] not in _EXEMPT_DIRS
+    )
+
+
+def _test_stems() -> set[str]:
+    """Return the set of ``<stem>`` for every ``test_<stem>.py`` under tests/."""
+    return {p.stem[len("test_") :] for p in _test_files()}
+
+
+def _is_cross_cutting(stem: str) -> bool:
+    """Return whether *stem* names a declared cross-cutting behaviour suite."""
+    return stem in ALLOWED_ORPHANS or stem.endswith(ORPHAN_SUFFIXES)
+
+
+def check() -> list[str]:
+    """Return a list of layout violations (empty when the layout is clean)."""
+    errors: list[str] = []
+
+    # Forward: every public source module must be tested somewhere.
+    test_stems = _test_stems()
+    for module in _public_source_modules():
+        if module.stem not in test_stems:
+            errors.append(
+                f"missing test file test_{module.stem}.py (anywhere under tests/) "
+                f"for public source module {module.relative_to(ROOT)}"
+            )
+
+    # Reverse: every test file must name real code or a declared behaviour suite.
+    source_basenames = _source_basenames()
+    for test_file in _test_files():
+        stem = test_file.stem[len("test_") :]
+        if _is_cross_cutting(stem) or stem in source_basenames:
+            continue
+        errors.append(
+            f"orphan test file {test_file.relative_to(ROOT)} "
+            f"(no source module {stem}.py/_{stem}.py, and not a declared cross-cutting suite)"
+        )
+
+    return errors
+
+
+def main() -> int:
+    """Run the checks and return an exit code."""
+    errors = check()
+    if errors:
+        print("Test-layout check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"  ✗ {err}", file=sys.stderr)
+        return 1
+    print("Test-layout OK: every public module is tested; every test traces back to code.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/basanos/_logging.py
+++ b/src/basanos/_logging.py
@@ -58,6 +58,16 @@ _STDLIB_RECORD_ATTRS: frozenset[str] = frozenset(
 )
 
 
+def _serialise_mapping(value: dict[Any, Any]) -> dict[Any, Any]:
+    """Recursively coerce each value of a mapping into serialisable form."""
+    return {k: _to_serialisable(v) for k, v in value.items()}
+
+
+def _serialise_sequence(value: list[Any] | tuple[Any, ...]) -> list[Any]:
+    """Recursively coerce each element of a sequence into serialisable form."""
+    return [_to_serialisable(v) for v in value]
+
+
 def _to_serialisable(value: Any) -> Any:
     """Recursively coerce *value* into a JSON-serialisable form.
 
@@ -77,9 +87,9 @@ def _to_serialisable(value: Any) -> Any:
     if isinstance(value, float) and not math.isfinite(value):
         return str(value)
     if isinstance(value, dict):
-        return {k: _to_serialisable(v) for k, v in value.items()}
+        return _serialise_mapping(value)
     if isinstance(value, (list, tuple)):
-        return [_to_serialisable(v) for v in value]
+        return _serialise_sequence(value)
     return value
 
 

--- a/src/basanos/math/_config_report.py
+++ b/src/basanos/math/_config_report.py
@@ -61,14 +61,19 @@ def _constraint_str(field_info: object) -> str:
     return ", ".join(parts) if parts else "—"
 
 
+def _fmt_float(v: float) -> str:
+    """Format a float config value for compact display."""
+    if v == int(v) and abs(v) >= 1e4:
+        return f"{v:.2e}"
+    if abs(v) < 0.01 and v != 0.0:
+        return f"{v:.2e}"
+    return f"{v:g}"
+
+
 def _fmt_value(v: object) -> str:
     """Format a config field value for display."""
     if isinstance(v, float):
-        if v == int(v) and abs(v) >= 1e4:
-            return f"{v:.2e}"
-        if abs(v) < 0.01 and v != 0.0:
-            return f"{v:.2e}"
-        return f"{v:g}"
+        return _fmt_float(v)
     return str(v)
 
 

--- a/src/basanos/math/_engine_core.py
+++ b/src/basanos/math/_engine_core.py
@@ -1,0 +1,137 @@
+"""Core data-access mixin for `BasanosEngine`.
+
+Provides the volatility-adjusted returns, EWMA volatility, and per-timestamp
+correlation properties as a reusable mixin so that ``optimizer.py`` stays
+focused on the position-solving facade.
+
+Classes in this module are **private implementation details**.  The public API
+is `BasanosEngine`, which inherits from `_CoreDataMixin`.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+from cvx.linalg import cov_to_corr
+from cvx.linalg.covariance.ewm_cov import ewm_covariance
+
+from ._signal import vol_adj
+
+if TYPE_CHECKING:
+    from ._engine_protocol import _EngineProtocol
+
+
+class _CoreDataMixin:
+    """Mixin providing the core data-access properties of `BasanosEngine`.
+
+    The consuming class must satisfy `_EngineProtocol`, i.e. it must expose
+    ``prices`` (Polars DataFrame with a ``'date'`` column) and ``cfg``
+    (a `BasanosConfig`).
+    """
+
+    @property
+    def assets(self: _EngineProtocol) -> list[str]:
+        """List asset column names (numeric columns excluding 'date')."""
+        return [c for c in self.prices.columns if c != "date" and self.prices[c].dtype.is_numeric()]
+
+    @property
+    def ret_adj(self: _EngineProtocol) -> pl.DataFrame:
+        """Return per-asset volatility-adjusted log returns clipped by cfg.clip.
+
+        Uses an EWMA volatility estimate with lookback ``cfg.vola`` to
+        standardize log returns for each numeric asset column.
+        """
+        return self.prices.with_columns(
+            [vol_adj(pl.col(asset), vola=self.cfg.vola, clip=self.cfg.clip) for asset in self.assets]
+        )
+
+    @property
+    def vola(self: _EngineProtocol) -> pl.DataFrame:
+        """Per-asset EWMA volatility of percentage returns.
+
+        Computes percent changes for each numeric asset column and applies an
+        exponentially weighted standard deviation using the lookback specified
+        by ``cfg.vola``. The result is a DataFrame aligned with ``self.prices``
+        whose numeric columns hold per-asset volatility estimates.
+        """
+        return self.prices.with_columns(
+            pl.col(asset)
+            .pct_change()
+            .ewm_std(com=self.cfg.vola - 1, adjust=True, min_samples=self.cfg.vola)
+            .alias(asset)
+            for asset in self.assets
+        )
+
+    @property
+    def cor(self: _EngineProtocol) -> dict[datetime.date, np.ndarray]:
+        """Compute per-timestamp EWM correlation matrices.
+
+        Builds volatility-adjusted returns for all assets, computes an
+        exponentially weighted correlation using a pure NumPy implementation
+        (with window ``cfg.corr``), and returns a mapping from each timestamp
+        to the corresponding correlation matrix as a NumPy array.
+
+        Returns:
+            dict: Mapping ``date -> np.ndarray`` of shape (n_assets, n_assets).
+
+        Performance:
+            Delegates to ``ewm_covariance`` from ``cvx.linalg``.
+            For large *N* or *T*, prefer ``cor_tensor`` to keep a single
+            contiguous array rather than building a Python dict.
+        """
+        assets = list(self.assets)
+        n = len(assets)
+        span = 2 * self.cfg.corr + 1
+        cov_dict = ewm_covariance(
+            self.ret_adj,
+            assets=assets,
+            index_col="date",
+            window=span,
+            warmup=self.cfg.corr,
+        )
+        nan_mat = np.full((n, n), np.nan)
+        return {
+            date: cov_to_corr(cov_dict[date], self.cfg.min_corr_denom) if date in cov_dict else nan_mat.copy()
+            for date in self.prices["date"].to_list()
+        }
+
+    @property
+    def cor_tensor(self: _EngineProtocol) -> np.ndarray:
+        """Return all correlation matrices stacked as a 3-D tensor.
+
+        Converts the per-timestamp correlation dict (see `cor`) into a
+        single contiguous NumPy array so that the full history can be saved to
+        a flat ``.npy`` file with `save` and reloaded with
+        `load`.
+
+        Returns:
+            np.ndarray: Array of shape ``(T, N, N)`` where *T* is the number of
+            timestamps and *N* the number of assets.  ``tensor[t]`` is the
+            correlation matrix for the *t*-th date (same ordering as
+            ``self.prices["date"]``).
+
+        Examples:
+            >>> import tempfile, pathlib
+            >>> import numpy as np
+            >>> import polars as pl
+            >>> from basanos.math.optimizer import BasanosConfig, BasanosEngine
+            >>> dates = pl.Series("date", list(range(100)))
+            >>> rng0 = np.random.default_rng(0).lognormal(size=100)
+            >>> rng1 = np.random.default_rng(1).lognormal(size=100)
+            >>> prices = pl.DataFrame({"date": dates, "A": rng0, "B": rng1})
+            >>> rng2 = np.random.default_rng(2).normal(size=100)
+            >>> rng3 = np.random.default_rng(3).normal(size=100)
+            >>> mu = pl.DataFrame({"date": dates, "A": rng2, "B": rng3})
+            >>> cfg = BasanosConfig(vola=10, corr=20, clip=3.0, shrink=0.5, aum=1e6)
+            >>> engine = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
+            >>> tensor = engine.cor_tensor
+            >>> with tempfile.TemporaryDirectory() as td:
+            ...     path = pathlib.Path(td) / "cor.npy"
+            ...     np.save(path, tensor)
+            ...     loaded = np.load(path)
+            >>> np.testing.assert_array_equal(tensor, loaded)
+        """
+        return np.stack(list(self.cor.values()), axis=0)

--- a/src/basanos/math/_engine_diagnostics.py
+++ b/src/basanos/math/_engine_diagnostics.py
@@ -104,6 +104,30 @@ class _DiagnosticsMixin:
 
         return pl.DataFrame({"date": self.prices["date"], "effective_rank": pl.Series(ranks, dtype=pl.Float64)})
 
+    @staticmethod
+    def _residual_for_row(matrix: np.ndarray, expected_mu: np.ndarray, t: object) -> float:
+        """Return the solver residual for a single timestamp.
+
+        Returns ``0.0`` for an all-zero signal (no solve performed) and
+        ``NaN`` when the matrix is singular or the solution has no finite
+        entries.
+        """
+        if np.allclose(expected_mu, 0.0):
+            return 0.0
+        try:
+            x = solve(matrix, expected_mu)
+        except SingularMatrixError:
+            # The covariance matrix is degenerate — residual is undefined.
+            _logger.warning(
+                "solver_residual: SingularMatrixError at t=%s - covariance matrix is degenerate; residual set to NaN.",
+                t,
+            )
+            return float(np.nan)
+        finite_x = np.isfinite(x)
+        if not finite_x.any():
+            return float(np.nan)
+        return float(np.linalg.norm(matrix[np.ix_(finite_x, finite_x)] @ x[finite_x] - expected_mu[finite_x]))
+
     @property
     def solver_residual(self: _EngineProtocol) -> pl.DataFrame:
         r"""Per-timestamp solver residual ``‖C·x - μ‖₂``.
@@ -128,31 +152,34 @@ class _DiagnosticsMixin:
             if bundle is None:
                 residuals.append(float(np.nan))
                 continue
-            matrix = bundle.matrix
             expected_mu = np.nan_to_num(mu_np[i][mask])
-            if np.allclose(expected_mu, 0.0):
-                residuals.append(0.0)
-                continue
-            try:
-                x = solve(matrix, expected_mu)
-            except SingularMatrixError:
-                # The covariance matrix is degenerate — residual is undefined.
-                _logger.warning(
-                    "solver_residual: SingularMatrixError at t=%s - covariance matrix is "
-                    "degenerate; residual set to NaN.",
-                    t,
-                )
-                residuals.append(float(np.nan))
-                continue
-            finite_x = np.isfinite(x)
-            if not finite_x.any():
-                residuals.append(float(np.nan))
-                continue
-            residuals.append(
-                float(np.linalg.norm(matrix[np.ix_(finite_x, finite_x)] @ x[finite_x] - expected_mu[finite_x]))
-            )
+            residuals.append(_DiagnosticsMixin._residual_for_row(bundle.matrix, expected_mu, t))
 
         return pl.DataFrame({"date": self.prices["date"], "residual": pl.Series(residuals, dtype=pl.Float64)})
+
+    @staticmethod
+    def _utilisation_for_row(
+        matrix: np.ndarray, expected_mu: np.ndarray, t: object, mu_tol: float
+    ) -> np.ndarray | None:
+        """Return the per-asset utilisation ratios for a single timestamp.
+
+        Returns an all-zero vector for an all-zero signal (no solve performed)
+        and ``None`` when the matrix is singular (utilisation left as ``NaN``).
+        """
+        if np.allclose(expected_mu, 0.0):
+            return np.zeros_like(expected_mu)
+        try:
+            x = solve(matrix, expected_mu)
+        except SingularMatrixError:
+            # The covariance matrix is degenerate — utilisation is undefined.
+            _logger.warning(
+                "signal_utilisation: SingularMatrixError at t=%s - covariance matrix is "
+                "degenerate; utilisation set to NaN.",
+                t,
+            )
+            return None
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return np.where(np.abs(expected_mu) > mu_tol, x / expected_mu, np.nan)
 
     @property
     def signal_utilisation(self: _EngineProtocol) -> pl.DataFrame:
@@ -189,23 +216,9 @@ class _DiagnosticsMixin:
         for i, t, mask, bundle in self._iter_matrices():
             if bundle is None:
                 continue
-            matrix = bundle.matrix
             expected_mu = np.nan_to_num(mu_np[i][mask])
-            if np.allclose(expected_mu, 0.0):
-                util_np[i, mask] = 0.0
-                continue
-            try:
-                x = solve(matrix, expected_mu)
-            except SingularMatrixError:
-                # The covariance matrix is degenerate — utilisation is undefined.
-                _logger.warning(
-                    "signal_utilisation: SingularMatrixError at t=%s - covariance matrix is "
-                    "degenerate; utilisation set to NaN.",
-                    t,
-                )
-                continue
-            with np.errstate(divide="ignore", invalid="ignore"):
-                ratio = np.where(np.abs(expected_mu) > _mu_tol, x / expected_mu, np.nan)
-            util_np[i, mask] = ratio
+            ratio = _DiagnosticsMixin._utilisation_for_row(bundle.matrix, expected_mu, t, _mu_tol)
+            if ratio is not None:
+                util_np[i, mask] = ratio
 
         return self.prices.with_columns([pl.lit(util_np[:, j]).alias(asset) for j, asset in enumerate(assets)])

--- a/src/basanos/math/_engine_ic.py
+++ b/src/basanos/math/_engine_ic.py
@@ -20,6 +20,33 @@ if TYPE_CHECKING:
     from ._engine_protocol import _EngineProtocol
 
 
+def _correlate(signal: np.ndarray, fwd_ret: np.ndarray, *, use_rank: bool) -> float:
+    """Correlate two finite vectors, returning ``nan`` for degenerate input.
+
+    Both `np.corrcoef` and `scipy.stats.spearmanr` emit warnings (numpy
+    ``invalid value encountered in divide``; scipy ``ConstantInputWarning``)
+    and yield ``nan`` when either input has zero variance (a constant column).
+    That degenerate case is expected — an IC is undefined when a signal or the
+    forward returns are flat — so it is short-circuited to ``nan`` here before
+    the correlation is attempted, keeping the test log and any downstream
+    caller free of the warning.
+
+    Args:
+        signal: Finite signal values for the assets valid at this timestamp.
+        fwd_ret: Matching finite forward returns.
+        use_rank: When ``True`` use Spearman rank correlation; otherwise Pearson.
+
+    Returns:
+        float: The correlation, or ``nan`` when either input is constant.
+    """
+    if signal.std() == 0.0 or fwd_ret.std() == 0.0:
+        return float("nan")
+    if use_rank:
+        corr, _ = spearmanr(signal, fwd_ret)
+        return float(corr)
+    return float(np.corrcoef(signal, fwd_ret)[0, 1])
+
+
 class _SignalEvaluatorMixin:
     """Mixin providing cross-sectional information-coefficient (IC) metrics.
 
@@ -75,14 +102,9 @@ class _SignalEvaluatorMixin:
             mask = np.isfinite(signal) & np.isfinite(fwd_ret)
             n_valid = int(mask.sum())
 
-            if n_valid < 2:
-                ic_values.append(float("nan"))
-            elif use_rank:
-                corr, _ = spearmanr(signal[mask], fwd_ret[mask])
-                ic_values.append(float(corr))
-            else:
-                ic_values.append(float(np.corrcoef(signal[mask], fwd_ret[mask])[0, 1]))
-
+            ic_values.append(
+                _correlate(signal[mask], fwd_ret[mask], use_rank=use_rank) if n_valid >= 2 else float("nan")
+            )
             ic_dates.append(dates[t])
 
         return pl.DataFrame({"date": ic_dates, col_name: pl.Series(ic_values, dtype=pl.Float64)})

--- a/src/basanos/math/_engine_performance.py
+++ b/src/basanos/math/_engine_performance.py
@@ -1,0 +1,176 @@
+"""Performance / parameter-sweep mixin for `BasanosEngine`.
+
+Provides the Sharpe-ratio sweep helpers (`sharpe_at_shrink`,
+`sharpe_at_window_factors`, `naive_sharpe`) as a reusable mixin so that
+``optimizer.py`` stays focused on the position-solving facade.  Each helper
+rebuilds a sibling engine with a modified configuration, so it constructs a new
+`BasanosEngine` via a deferred import (avoiding a circular import at module
+load time).
+
+Classes in this module are **private implementation details**.  The public API
+is `BasanosEngine`, which inherits from `_PerformanceMixin`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+from ._config import SlidingWindowConfig
+
+if TYPE_CHECKING:
+    from ._engine_protocol import _EngineProtocol
+
+
+class _PerformanceMixin:
+    """Mixin providing portfolio-Sharpe sweep helpers for `BasanosEngine`.
+
+    The consuming class must satisfy `_EngineProtocol` (it uses ``assets``,
+    ``prices``, ``mu``, and ``cfg``).
+    """
+
+    def sharpe_at_shrink(self: _EngineProtocol, shrink: float) -> float:
+        r"""Return the annualised portfolio Sharpe ratio for the given shrinkage weight.
+
+        Constructs a new `BasanosEngine` with all parameters identical to
+        ``self`` except that ``cfg.shrink`` is replaced by ``shrink``, then
+        returns the annualised Sharpe ratio of the resulting portfolio.
+
+        This is the canonical single-argument callable required by the benchmarks
+        specification: ``f(λ) → Sharpe``.  Use it to sweep λ across ``[0, 1]``
+        and measure whether correlation adjustment adds value over the
+        signal-proportional baseline (λ = 0) or the unregularised limit (λ = 1).
+
+        Corner cases:
+            * **λ = 0** — the shrunk matrix equals the identity, so the
+              optimiser treats all assets as uncorrelated and positions are
+              purely signal-proportional (no correlation adjustment).
+            * **λ = 1** — the raw EWMA correlation matrix is used without
+              shrinkage.
+
+        Args:
+            shrink: Retention weight λ ∈ [0, 1].  See
+                `shrink` for full documentation.
+
+        Returns:
+            Annualised Sharpe ratio of the portfolio returns as a ``float``.
+            Returns ``float("nan")`` when the Sharpe ratio cannot be computed
+            (e.g. zero-variance returns).
+
+        Raises:
+            ValidationError: When ``shrink`` is outside [0, 1] (delegated to
+                `BasanosConfig` field validation).
+
+        Examples:
+            >>> import numpy as np
+            >>> import polars as pl
+            >>> from basanos.math.optimizer import BasanosConfig, BasanosEngine
+            >>> dates = pl.Series("date", list(range(200)))
+            >>> rng = np.random.default_rng(0)
+            >>> prices = pl.DataFrame({"date": dates, "A": rng.lognormal(size=200), "B": rng.lognormal(size=200)})
+            >>> mu = pl.DataFrame({"date": dates, "A": rng.normal(size=200), "B": rng.normal(size=200)})
+            >>> cfg = BasanosConfig(vola=10, corr=20, clip=3.0, shrink=0.5, aum=1e6)
+            >>> engine = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
+            >>> s = engine.sharpe_at_shrink(0.5)
+            >>> isinstance(s, float)
+            True
+        """
+        from .optimizer import BasanosEngine  # deferred to avoid a circular import
+
+        new_cfg = self.cfg.replace(shrink=shrink)
+        engine = BasanosEngine(prices=self.prices, mu=self.mu, cfg=new_cfg)
+        return float(engine.portfolio.stats.sharpe().get("returns") or float("nan"))
+
+    def sharpe_at_window_factors(self: _EngineProtocol, window: int, n_factors: int) -> float:
+        r"""Return the annualised portfolio Sharpe ratio for the given sliding-window parameters.
+
+        Constructs a new `BasanosEngine` with ``covariance_mode`` set to
+        ``"sliding_window"`` and the supplied ``window`` / ``n_factors``, keeping
+        all other configuration identical to ``self``.
+
+        Use this method to sweep ``(W, k)`` and compare the sliding-window
+        estimator against the EWMA baseline (via `sharpe_at_shrink`).
+
+        Args:
+            window: Rolling window length $W \geq 1$.
+                Rule of thumb: $W \geq 2 \cdot n_{\text{assets}}$.
+            n_factors: Number of latent factors $k \geq 1$.
+
+        Returns:
+            Annualised Sharpe ratio of the portfolio returns as a ``float``.
+            Returns ``float("nan")`` when the Sharpe ratio cannot be computed
+            (e.g. not enough history to fill the first window).
+
+        Raises:
+            ValidationError: When ``window`` or ``n_factors`` fail field
+                constraints (delegated to `BasanosConfig`).
+
+        Examples:
+            >>> import numpy as np
+            >>> import polars as pl
+            >>> from basanos.math.optimizer import BasanosConfig, BasanosEngine
+            >>> dates = pl.Series("date", list(range(200)))
+            >>> rng = np.random.default_rng(0)
+            >>> prices = pl.DataFrame({"date": dates, "A": rng.lognormal(size=200), "B": rng.lognormal(size=200)})
+            >>> mu = pl.DataFrame({"date": dates, "A": rng.normal(size=200), "B": rng.normal(size=200)})
+            >>> cfg = BasanosConfig(vola=10, corr=20, clip=3.0, shrink=0.5, aum=1e6)
+            >>> engine = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
+            >>> s = engine.sharpe_at_window_factors(window=40, n_factors=2)
+            >>> isinstance(s, float)
+            True
+        """
+        from .optimizer import BasanosEngine  # deferred to avoid a circular import
+
+        new_cfg = self.cfg.replace(
+            covariance_config=SlidingWindowConfig(window=window, n_factors=n_factors),
+        )
+        engine = BasanosEngine(prices=self.prices, mu=self.mu, cfg=new_cfg)
+        return float(engine.portfolio.stats.sharpe().get("returns") or float("nan"))
+
+    @property
+    def naive_sharpe(self: _EngineProtocol) -> float:
+        r"""Sharpe ratio of the naïve equal-weight signal (μ = 1 for every asset/timestamp).
+
+        Replaces the expected-return signal ``mu`` with a constant matrix of
+        ones, then runs the optimiser with the current configuration and returns
+        the annualised Sharpe ratio of the resulting portfolio.
+
+        This provides the baseline answer to *"does the signal add value?"*:
+        a real signal should produce a higher Sharpe than the naïve benchmark.
+        Combined with `sharpe_at_shrink`, this yields a three-way
+        comparison:
+
+        +--------------------+----------------------------------------------+
+        | Benchmark          | What it measures                             |
+        +====================+==============================================+
+        | ``naive_sharpe``   | No signal skill; pure correlation routing   |
+        +--------------------+----------------------------------------------+
+        | ``sharpe_at_shrink(0.0)`` | Signal skill, no correlation adj.  |
+        +--------------------+----------------------------------------------+
+        | ``sharpe_at_shrink(cfg.shrink)`` | Signal + correlation adj.  |
+        +--------------------+----------------------------------------------+
+
+        Returns:
+            Annualised Sharpe ratio of the equal-weight portfolio as a ``float``.
+            Returns ``float("nan")`` when the Sharpe ratio cannot be computed.
+
+        Examples:
+            >>> import numpy as np
+            >>> import polars as pl
+            >>> from basanos.math.optimizer import BasanosConfig, BasanosEngine
+            >>> dates = pl.Series("date", list(range(200)))
+            >>> rng = np.random.default_rng(0)
+            >>> prices = pl.DataFrame({"date": dates, "A": rng.lognormal(size=200), "B": rng.lognormal(size=200)})
+            >>> mu = pl.DataFrame({"date": dates, "A": rng.normal(size=200), "B": rng.normal(size=200)})
+            >>> cfg = BasanosConfig(vola=10, corr=20, clip=3.0, shrink=0.5, aum=1e6)
+            >>> engine = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
+            >>> s = engine.naive_sharpe
+            >>> isinstance(s, float)
+            True
+        """
+        from .optimizer import BasanosEngine  # deferred to avoid a circular import
+
+        naive_mu = self.mu.with_columns(pl.lit(1.0).alias(asset) for asset in self.assets)
+        engine = BasanosEngine(prices=self.prices, mu=naive_mu, cfg=self.cfg)
+        return float(engine.portfolio.stats.sharpe().get("returns") or float("nan"))

--- a/src/basanos/math/_engine_solve.py
+++ b/src/basanos/math/_engine_solve.py
@@ -8,17 +8,21 @@ the per-timestamp solve logic independently readable and testable.
 
 from __future__ import annotations
 
-import dataclasses
 import datetime
 import logging
 from collections.abc import Generator
-from enum import StrEnum
-from typing import TYPE_CHECKING, TypeAlias, cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 from cvx.linalg import SingularMatrixError, inv_a_norm, solve
 
 from ._config import EwmaShrinkConfig, SlidingWindowConfig
+from ._engine_solve_base import MatrixBundle as MatrixBundle
+from ._engine_solve_base import MatrixYield as MatrixYield
+from ._engine_solve_base import SolveStatus as SolveStatus
+from ._engine_solve_base import SolveYield as SolveYield
+from ._engine_solve_base import WarmupState as WarmupState
+from ._engine_solve_base import _SolvePrimitivesMixin
 from ._factor_model import FactorModel
 from ._signal import shrink2id
 
@@ -28,191 +32,15 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
-class SolveStatus(StrEnum):
-    """Solver outcome labels for each timestamp.
-
-    Since `SolveStatus` inherits from `str` via ``StrEnum``,
-    values compare equal to their string equivalents (e.g.
-    ``SolveStatus.VALID == "valid"``), preserving backward compatibility
-    with code that matches on string literals.
-
-    Attributes:
-        WARMUP: Insufficient history for the sliding-window covariance mode.
-        ZERO_SIGNAL: The expected-return vector was all-zero; positions zeroed.
-        DEGENERATE: Normalisation denominator was non-finite, solve failed, or
-            no asset had a finite price; positions zeroed for safety.
-        VALID: Linear system solved successfully; positions are non-trivially
-            non-zero.
-    """
-
-    WARMUP = "warmup"
-    ZERO_SIGNAL = "zero_signal"
-    DEGENERATE = "degenerate"
-    VALID = "valid"
-
-
-@dataclasses.dataclass(frozen=True)
-class MatrixBundle:
-    """Container for the covariance matrix and any mode-specific auxiliary state.
-
-    Wrapping the covariance matrix in a dataclass decouples
-    `_compute_position` from the raw array so that future
-    covariance modes (e.g. DCC-GARCH, RMT-cleaned) can carry additional fields
-    through the same interface without changing the method signature.
-
-    Attributes:
-        matrix: The ``(n_active, n_active)`` covariance sub-matrix for the
-            active assets at a given timestamp.
-    """
-
-    matrix: np.ndarray
-
-
-#: Yield type for `_iter_matrices`:
-#: ``(i, t, mask, bundle)`` where ``bundle`` is ``None`` during warmup/no-data.
-MatrixYield: TypeAlias = tuple[int, datetime.date, np.ndarray, MatrixBundle | None]
-
-#: Yield type for `_iter_solve`:
-#: ``(i, t, mask, pos_or_none, status)`` where ``pos_or_none`` is ``None`` only for warmup rows.
-SolveYield: TypeAlias = tuple[int, datetime.date, np.ndarray, np.ndarray | None, SolveStatus]
-
-
-@dataclasses.dataclass(frozen=True)
-class WarmupState:
-    """Final state produced by a full batch solve; consumed by `from_warmup`.
-
-    Returned by `warmup_state` and used by
-    `from_warmup` to initialise the streaming state without
-    coupling to the private `_iter_solve` generator.
-
-    Attributes:
-        prev_cash_pos: Cash positions at the last warmup row, shape
-            ``(n_assets,)``.  ``NaN`` for assets that were still in their
-            own warmup period.
-    """
-
-    prev_cash_pos: np.ndarray
-
-
-class _SolveMixin:
+class _SolveMixin(_SolvePrimitivesMixin):
     """Mixin that provides ``_iter_matrices`` and ``_iter_solve`` generators.
 
-    Consumers must also inherit from (or satisfy the interface of)
-    `_EngineProtocol` so that
+    Inherits the stateless helpers from `_SolvePrimitivesMixin` and adds the
+    per-timestamp solve orchestration.  Consumers must also inherit from (or
+    satisfy the interface of) `_EngineProtocol` so that
     ``self.assets``, ``self.prices``, ``self.mu``, ``self.cfg``, ``self.cor``,
     and ``self.ret_adj`` are all available.
     """
-
-    @staticmethod
-    def _compute_mask(prices_row: np.ndarray) -> np.ndarray:
-        """Return boolean mask indicating which assets have finite prices in the given row."""
-        mask: np.ndarray = np.isfinite(prices_row)
-        return mask
-
-    @staticmethod
-    def _check_signal(mu: np.ndarray, mask: np.ndarray) -> SolveStatus | None:
-        """Return ``ZERO_SIGNAL`` when the masked expected-return vector is all-zero.
-
-        Returns ``None`` when the signal is non-trivially non-zero, indicating
-        that the caller should proceed to the linear solve.
-        """
-        if np.allclose(np.nan_to_num(mu[mask]), 0.0):
-            return SolveStatus.ZERO_SIGNAL
-        return None
-
-    @staticmethod
-    def _scale_to_cash(pos: np.ndarray, vola_active: np.ndarray) -> np.ndarray:
-        """Convert raw solver positions to cash-adjusted positions.
-
-        Divides *pos* by *vola_active* (volatility for the active asset subset)
-        to get cash positions.  ``np.errstate(invalid="ignore")`` is applied
-        internally so NaN volatility values propagate quietly.
-        """
-        with np.errstate(invalid="ignore"):
-            return cast("np.ndarray", pos / vola_active)
-
-    @staticmethod
-    def _row_early_check(
-        i: int,
-        t: datetime.date,
-        mask: np.ndarray,
-        mu_row: np.ndarray,
-    ) -> tuple[np.ndarray, SolveYield | None]:
-        """Validate the price mask and expected-return signal for a single row.
-
-        Returns an ``(expected_mu, early_yield)`` pair.  When ``early_yield``
-        is not ``None``, the caller should ``yield early_yield; continue``
-        immediately — the row is either degenerate (empty mask) or has an
-        all-zero signal.  When ``early_yield`` is ``None`` the row is ready
-        for the mode-specific solve step.
-
-        Args:
-            i: Row index.
-            t: Timestamp.
-            mask: Boolean array of shape ``(n_assets,)`` indicating finite prices.
-            mu_row: Expected-return row of shape ``(n_assets,)``.
-
-        Returns:
-            tuple: ``(expected_mu, early_yield)`` where ``expected_mu`` is
-            ``np.nan_to_num(mu_row[mask])`` and ``early_yield`` is either a
-            complete `SolveYield` tuple (when the caller should yield
-            and continue) or ``None`` (when the caller should proceed to solve).
-        """
-        if not mask.any():
-            return np.zeros(0), (i, t, mask, np.zeros(0), SolveStatus.DEGENERATE)
-        expected_mu = np.nan_to_num(mu_row[mask])
-        sig_status = _SolveMixin._check_signal(mu_row, mask)
-        if sig_status is not None:
-            return expected_mu, (i, t, mask, np.zeros_like(expected_mu), sig_status)
-        return expected_mu, None
-
-    @staticmethod
-    def _denom_guard_yield(
-        i: int,
-        t: datetime.date,
-        mask: np.ndarray,
-        expected_mu: np.ndarray,
-        pos_raw: np.ndarray,
-        denom: float,
-        denom_tol: float,
-    ) -> SolveYield:
-        """Apply the normalisation-denominator guard and return the appropriate yield tuple.
-
-        Emits a `WARNING` and returns a
-        `DEGENERATE` yield when *denom* is non-finite or at
-        or below *denom_tol*; otherwise returns a `VALID`
-        yield with normalised positions ``pos_raw / denom``.
-
-        Args:
-            i: Row index.
-            t: Timestamp.
-            mask: Boolean asset mask of shape ``(n_assets,)``.
-            expected_mu: Masked expected-return vector of shape ``(n_active,)``.
-            pos_raw: Raw (pre-normalisation) position vector of shape ``(n_active,)``.
-            denom: Computed normalisation denominator.
-            denom_tol: Tolerance threshold below which *denom* is treated as degenerate.
-
-        Returns:
-            SolveYield: Either a degenerate or valid ``(i, t, mask, pos, status)`` tuple.
-        """
-        n_active = len(expected_mu)
-        if not np.isfinite(denom) or denom <= denom_tol:
-            _logger.warning(
-                "Positions zeroed at t=%s: normalisation denominator is degenerate "
-                "(denom=%s, denom_tol=%s). Check signal magnitude and covariance matrix.",
-                t,
-                denom,
-                denom_tol,
-                extra={
-                    "context": {
-                        "t": str(t),
-                        "denom": denom,
-                        "denom_tol": denom_tol,
-                    }
-                },
-            )
-            return i, t, mask, np.zeros(n_active), SolveStatus.DEGENERATE
-        return i, t, mask, pos_raw / denom, SolveStatus.VALID
 
     @staticmethod
     def _compute_position(
@@ -256,38 +84,6 @@ class _SolveMixin:
         except SingularMatrixError:
             return i, t, mask, np.zeros_like(expected_mu), SolveStatus.DEGENERATE
         return _SolveMixin._denom_guard_yield(i, t, mask, expected_mu, pos, denom, denom_tol)
-
-    @staticmethod
-    def _apply_turnover_constraint(
-        new_cash: np.ndarray,
-        prev_cash: np.ndarray,
-        max_turnover: float,
-    ) -> np.ndarray:
-        """Cap the L1 norm of the position change to *max_turnover*.
-
-        When ``sum(|new_cash - prev_cash|) > max_turnover``, the delta is
-        scaled back proportionally toward *prev_cash* so that the constraint
-        is exactly met.  When the constraint is already satisfied the input is
-        returned unchanged.
-
-        Args:
-            new_cash: Proposed cash positions after the solve step, shape
-                ``(n_active,)`` — ``NaN`` values treated as zero.
-            prev_cash: Cash positions at the previous step, shape
-                ``(n_active,)`` — ``NaN`` values treated as zero.
-            max_turnover: Maximum allowed L1 norm of the position change.
-
-        Returns:
-            np.ndarray: The (possibly scaled) new cash positions.
-        """
-        curr = np.nan_to_num(new_cash, nan=0.0)
-        prev = np.nan_to_num(prev_cash, nan=0.0)
-        delta = curr - prev
-        total_delta = float(np.sum(np.abs(delta)))
-        if total_delta > max_turnover:
-            scale = max_turnover / total_delta
-            return cast("np.ndarray", prev + delta * scale)
-        return new_cash
 
     def _replay_positions(
         self: _EngineProtocol,
@@ -348,40 +144,65 @@ class _SolveMixin:
             * ``bundle`` (`MatrixBundle` | ``None``): Covariance bundle
               of shape ``(mask.sum(), mask.sum())``, or ``None``.
         """
-        assets = self.assets
-        prices_num = self.prices.select(assets).to_numpy()
+        prices_num = self.prices.select(self.assets).to_numpy()
         dates = self.prices["date"].to_list()
 
         if isinstance(self.cfg.covariance_config, EwmaShrinkConfig):
-            cor = self.cor
-            for i, t in enumerate(dates):
-                mask = _SolveMixin._compute_mask(prices_num[i])
-                if not mask.any():
-                    yield i, t, mask, None
-                    continue
-                corr_n = cor[t]
-                matrix = shrink2id(corr_n, lamb=self.cfg.shrink)[np.ix_(mask, mask)]
-                yield i, t, mask, MatrixBundle(matrix=matrix)
+            yield from _SolveMixin._iter_matrices_ewma(self, prices_num, dates)
         else:
-            sw_config = self.cfg.covariance_config
-            win_w: int = sw_config.window
-            win_k: int = sw_config.n_factors
-            ret_adj_np = self.ret_adj.select(assets).to_numpy()
-            for i, t in enumerate(dates):
-                mask = _SolveMixin._compute_mask(prices_num[i])
-                if not mask.any() or i + 1 < win_w:
-                    yield i, t, mask, None
-                    continue
-                window_ret = ret_adj_np[i + 1 - win_w : i + 1][:, mask]
-                window_ret = np.where(np.isfinite(window_ret), window_ret, 0.0)
-                n_sub = int(mask.sum())
-                k_eff = min(win_k, win_w, n_sub)
-                try:
-                    fm = FactorModel.from_returns(window_ret, k=k_eff)
-                    yield i, t, mask, MatrixBundle(matrix=fm.covariance)
-                except (np.linalg.LinAlgError, ValueError) as exc:
-                    _logger.warning("Factor model fit failed at t=%s: %s", t, exc)
-                    yield i, t, mask, None
+            yield from _SolveMixin._iter_matrices_sliding(self, prices_num, dates)
+
+    def _iter_matrices_ewma(
+        self: _EngineProtocol,
+        prices_num: np.ndarray,
+        dates: list[datetime.date],
+    ) -> Generator[MatrixYield, None, None]:
+        """Yield per-timestamp `MatrixYield` for the `EwmaShrinkConfig` path.
+
+        Applies `shrink2id` to the EWMA correlation matrix and restricts it to
+        the active-asset sub-matrix; yields ``None`` when no asset has a finite
+        price at that row.
+        """
+        cor = self.cor
+        for i, t in enumerate(dates):
+            mask = _SolveMixin._compute_mask(prices_num[i])
+            if not mask.any():
+                yield i, t, mask, None
+                continue
+            corr_n = cor[t]
+            matrix = shrink2id(corr_n, lamb=self.cfg.shrink)[np.ix_(mask, mask)]
+            yield i, t, mask, MatrixBundle(matrix=matrix)
+
+    def _iter_matrices_sliding(
+        self: _EngineProtocol,
+        prices_num: np.ndarray,
+        dates: list[datetime.date],
+    ) -> Generator[MatrixYield, None, None]:
+        """Yield per-timestamp `MatrixYield` for the `SlidingWindowConfig` path.
+
+        Fits a `FactorModel` from the last ``window`` rows of vol-adjusted
+        returns; yields ``None`` during warm-up, when no asset has a finite
+        price, or when the factor-model fit fails.
+        """
+        sw_config = cast(SlidingWindowConfig, self.cfg.covariance_config)
+        win_w: int = sw_config.window
+        win_k: int = sw_config.n_factors
+        ret_adj_np = self.ret_adj.select(self.assets).to_numpy()
+        for i, t in enumerate(dates):
+            mask = _SolveMixin._compute_mask(prices_num[i])
+            if not mask.any() or i + 1 < win_w:
+                yield i, t, mask, None
+                continue
+            window_ret = ret_adj_np[i + 1 - win_w : i + 1][:, mask]
+            window_ret = np.where(np.isfinite(window_ret), window_ret, 0.0)
+            n_sub = int(mask.sum())
+            k_eff = min(win_k, win_w, n_sub)
+            try:
+                fm = FactorModel.from_returns(window_ret, k=k_eff)
+                yield i, t, mask, MatrixBundle(matrix=fm.covariance)
+            except (np.linalg.LinAlgError, ValueError) as exc:
+                _logger.warning("Factor model fit failed at t=%s: %s", t, exc)
+                yield i, t, mask, None
 
     @staticmethod
     def _batched_solve_group(
@@ -420,11 +241,7 @@ class _SolveMixin:
             pos_stack = np.linalg.solve(a_stack, mu_stack[..., np.newaxis])[..., 0]  # (G, n)
         except np.linalg.LinAlgError:
             # At least one matrix is singular — fall back to sequential per-row solve.
-            for i, t, mask, expected_mu, matrix in group:
-                results[i] = _SolveMixin._compute_position(
-                    i, t, mask, expected_mu, MatrixBundle(matrix=matrix), denom_tol
-                )
-            return results
+            return _SolveMixin._sequential_solve_group(group, denom_tol)
 
         # Denominators: sqrt(mu_i^T A_i^{-1} mu_i) = sqrt(mu_i · pos_i).
         dots = (mu_stack * pos_stack).sum(axis=1)  # (G,)
@@ -434,6 +251,21 @@ class _SolveMixin:
             results[i] = _SolveMixin._denom_guard_yield(i, t, mask, expected_mu, pos, float(denom), denom_tol)
 
         return results
+
+    @staticmethod
+    def _sequential_solve_group(
+        group: list[tuple[int, datetime.date, np.ndarray, np.ndarray, np.ndarray]],
+        denom_tol: float,
+    ) -> dict[int, SolveYield]:
+        """Row-by-row fallback used when a batched solve hits a singular matrix.
+
+        Solves each system in *group* independently via `_compute_position` so a
+        single ill-conditioned matrix does not abort the whole batch.
+        """
+        return {
+            i: _SolveMixin._compute_position(i, t, mask, expected_mu, MatrixBundle(matrix=matrix), denom_tol)
+            for i, t, mask, expected_mu, matrix in group
+        }
 
     @staticmethod
     def _iter_solve_ewma_batched(
@@ -468,22 +300,7 @@ class _SolveMixin:
             `SolveYield` tuples in original row order.
         """
         # First pass: categorise each row as early-exit or a solve candidate.
-        all_results: dict[int, SolveYield] = {}
-        # mask.tobytes() → list of (i, t, mask, expected_mu, matrix)
-        solve_groups: dict[bytes, list[tuple[int, datetime.date, np.ndarray, np.ndarray, np.ndarray]]] = {}
-
-        for i, t, mask, bundle in matrix_yields:
-            if bundle is None:
-                all_results[i] = (i, t, mask, np.zeros(int(mask.sum())), SolveStatus.DEGENERATE)
-                continue
-            expected_mu, early = _SolveMixin._row_early_check(i, t, mask, mu_np[i])
-            if early is not None:
-                all_results[i] = early
-                continue
-            mask_key = mask.tobytes()
-            if mask_key not in solve_groups:
-                solve_groups[mask_key] = []
-            solve_groups[mask_key].append((i, t, mask, expected_mu, bundle.matrix))
+        all_results, solve_groups = _SolveMixin._partition_ewma_rows(mu_np, matrix_yields)
 
         # Second pass: batch-solve each mask group.
         for group in solve_groups.values():
@@ -493,6 +310,37 @@ class _SolveMixin:
         for i in range(len(matrix_yields)):
             if i in all_results:
                 yield all_results[i]
+
+    @staticmethod
+    def _partition_ewma_rows(
+        mu_np: np.ndarray,
+        matrix_yields: list[MatrixYield],
+    ) -> tuple[
+        dict[int, SolveYield],
+        dict[bytes, list[tuple[int, datetime.date, np.ndarray, np.ndarray, np.ndarray]]],
+    ]:
+        """Split rows into resolved early-exits and mask-grouped solve candidates.
+
+        Returns ``(early_results, solve_groups)`` where ``early_results`` maps a
+        row index to its final `SolveYield` (no-data / warmup or an early
+        mask/signal exit) and ``solve_groups`` maps each ``mask.tobytes()`` key
+        to the rows sharing that active-asset pattern.
+        """
+        early_results: dict[int, SolveYield] = {}
+        # mask.tobytes() → list of (i, t, mask, expected_mu, matrix)
+        solve_groups: dict[bytes, list[tuple[int, datetime.date, np.ndarray, np.ndarray, np.ndarray]]] = {}
+
+        for i, t, mask, bundle in matrix_yields:
+            if bundle is None:
+                early_results[i] = (i, t, mask, np.zeros(int(mask.sum())), SolveStatus.DEGENERATE)
+                continue
+            expected_mu, early = _SolveMixin._row_early_check(i, t, mask, mu_np[i])
+            if early is not None:
+                early_results[i] = early
+                continue
+            solve_groups.setdefault(mask.tobytes(), []).append((i, t, mask, expected_mu, bundle.matrix))
+
+        return early_results, solve_groups
 
     def _iter_solve(self: _EngineProtocol) -> Generator[SolveYield, None, None]:
         r"""Yield ``(i, t, mask, pos_or_none, status)`` for every timestamp.
@@ -547,15 +395,22 @@ class _SolveMixin:
             return
 
         # SlidingWindowConfig path: sequential per-row solve (lazy factor models).
-        win_w: int = cov_config.window
+        yield from _SolveMixin._iter_solve_sliding(self, mu_np, cov_config.window)
 
+    def _iter_solve_sliding(
+        self: _EngineProtocol,
+        mu_np: np.ndarray,
+        win_w: int,
+    ) -> Generator[SolveYield, None, None]:
+        """Sequential per-row solve for the `SlidingWindowConfig` path.
+
+        Factor-model matrices are constructed lazily and may vary in numerical
+        character across rows, so each row is solved individually via
+        `_compute_position` rather than batched.
+        """
         for i, t, mask, bundle in self._iter_matrices():
             if bundle is None:
-                # Distinguish SW warmup (insufficient history) from no-data / model-failure.
-                if mask.any() and i + 1 < win_w:
-                    yield i, t, mask, None, SolveStatus.WARMUP
-                else:
-                    yield i, t, mask, np.zeros(int(mask.sum())), SolveStatus.DEGENERATE
+                yield _SolveMixin._sliding_warmup_or_degenerate(i, t, mask, win_w)
                 continue
             expected_mu, early = _SolveMixin._row_early_check(i, t, mask, mu_np[i])
             if early is not None:

--- a/src/basanos/math/_engine_solve_base.py
+++ b/src/basanos/math/_engine_solve_base.py
@@ -1,0 +1,263 @@
+"""Foundational types and stateless solve primitives for `_SolveMixin`.
+
+Holds the `SolveStatus` enum, the `MatrixBundle` / `WarmupState` carriers, the
+`MatrixYield` / `SolveYield` aliases, and `_SolvePrimitivesMixin` — the pure
+(``@staticmethod``) helpers that carry no dependency on the linear-algebra
+backend.  Splitting them out of ``_engine_solve`` keeps the solve-orchestration
+module focused on the generators that drive `BasanosEngine`.
+
+All public names are re-exported from ``_engine_solve`` so existing imports
+(``from basanos.math._engine_solve import MatrixBundle, SolveStatus, ...``) and
+the ``solve`` / ``inv_a_norm`` patch targets that live there are unchanged.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import logging
+from enum import StrEnum
+from typing import TypeAlias, cast
+
+import numpy as np
+
+# Solve-step warnings are emitted under the ``_engine_solve`` logger name (not
+# this module's ``__name__``) so the logging contract — log filters and the JSON
+# round-trip in the diagnostics — stays stable regardless of how the solve
+# helpers are split across private modules.
+_logger = logging.getLogger("basanos.math._engine_solve")
+
+
+class SolveStatus(StrEnum):
+    """Solver outcome labels for each timestamp.
+
+    Since `SolveStatus` inherits from `str` via ``StrEnum``,
+    values compare equal to their string equivalents (e.g.
+    ``SolveStatus.VALID == "valid"``), preserving backward compatibility
+    with code that matches on string literals.
+
+    Attributes:
+        WARMUP: Insufficient history for the sliding-window covariance mode.
+        ZERO_SIGNAL: The expected-return vector was all-zero; positions zeroed.
+        DEGENERATE: Normalisation denominator was non-finite, solve failed, or
+            no asset had a finite price; positions zeroed for safety.
+        VALID: Linear system solved successfully; positions are non-trivially
+            non-zero.
+    """
+
+    WARMUP = "warmup"
+    ZERO_SIGNAL = "zero_signal"
+    DEGENERATE = "degenerate"
+    VALID = "valid"
+
+
+@dataclasses.dataclass(frozen=True)
+class MatrixBundle:
+    """Container for the covariance matrix and any mode-specific auxiliary state.
+
+    Wrapping the covariance matrix in a dataclass decouples
+    `_compute_position` from the raw array so that future
+    covariance modes (e.g. DCC-GARCH, RMT-cleaned) can carry additional fields
+    through the same interface without changing the method signature.
+
+    Attributes:
+        matrix: The ``(n_active, n_active)`` covariance sub-matrix for the
+            active assets at a given timestamp.
+    """
+
+    matrix: np.ndarray
+
+
+#: Yield type for `_iter_matrices`:
+#: ``(i, t, mask, bundle)`` where ``bundle`` is ``None`` during warmup/no-data.
+MatrixYield: TypeAlias = tuple[int, datetime.date, np.ndarray, MatrixBundle | None]
+
+#: Yield type for `_iter_solve`:
+#: ``(i, t, mask, pos_or_none, status)`` where ``pos_or_none`` is ``None`` only for warmup rows.
+SolveYield: TypeAlias = tuple[int, datetime.date, np.ndarray, np.ndarray | None, SolveStatus]
+
+
+@dataclasses.dataclass(frozen=True)
+class WarmupState:
+    """Final state produced by a full batch solve; consumed by `from_warmup`.
+
+    Returned by `warmup_state` and used by
+    `from_warmup` to initialise the streaming state without
+    coupling to the private `_iter_solve` generator.
+
+    Attributes:
+        prev_cash_pos: Cash positions at the last warmup row, shape
+            ``(n_assets,)``.  ``NaN`` for assets that were still in their
+            own warmup period.
+    """
+
+    prev_cash_pos: np.ndarray
+
+
+class _SolvePrimitivesMixin:
+    """Stateless solve helpers shared by `_SolveMixin`.
+
+    Every method here is a ``@staticmethod`` that carries no dependency on the
+    linear-algebra backend, so it can be reasoned about (and reused) in
+    isolation from the per-timestamp solve generators.
+    """
+
+    @staticmethod
+    def _compute_mask(prices_row: np.ndarray) -> np.ndarray:
+        """Return boolean mask indicating which assets have finite prices in the given row."""
+        mask: np.ndarray = np.isfinite(prices_row)
+        return mask
+
+    @staticmethod
+    def _check_signal(mu: np.ndarray, mask: np.ndarray) -> SolveStatus | None:
+        """Return ``ZERO_SIGNAL`` when the masked expected-return vector is all-zero.
+
+        Returns ``None`` when the signal is non-trivially non-zero, indicating
+        that the caller should proceed to the linear solve.
+        """
+        if np.allclose(np.nan_to_num(mu[mask]), 0.0):
+            return SolveStatus.ZERO_SIGNAL
+        return None
+
+    @staticmethod
+    def _scale_to_cash(pos: np.ndarray, vola_active: np.ndarray) -> np.ndarray:
+        """Convert raw solver positions to cash-adjusted positions.
+
+        Divides *pos* by *vola_active* (volatility for the active asset subset)
+        to get cash positions.  ``np.errstate(invalid="ignore")`` is applied
+        internally so NaN volatility values propagate quietly.
+        """
+        with np.errstate(invalid="ignore"):
+            return cast("np.ndarray", pos / vola_active)
+
+    @staticmethod
+    def _row_early_check(
+        i: int,
+        t: datetime.date,
+        mask: np.ndarray,
+        mu_row: np.ndarray,
+    ) -> tuple[np.ndarray, SolveYield | None]:
+        """Validate the price mask and expected-return signal for a single row.
+
+        Returns an ``(expected_mu, early_yield)`` pair.  When ``early_yield``
+        is not ``None``, the caller should ``yield early_yield; continue``
+        immediately — the row is either degenerate (empty mask) or has an
+        all-zero signal.  When ``early_yield`` is ``None`` the row is ready
+        for the mode-specific solve step.
+
+        Args:
+            i: Row index.
+            t: Timestamp.
+            mask: Boolean array of shape ``(n_assets,)`` indicating finite prices.
+            mu_row: Expected-return row of shape ``(n_assets,)``.
+
+        Returns:
+            tuple: ``(expected_mu, early_yield)`` where ``expected_mu`` is
+            ``np.nan_to_num(mu_row[mask])`` and ``early_yield`` is either a
+            complete `SolveYield` tuple (when the caller should yield
+            and continue) or ``None`` (when the caller should proceed to solve).
+        """
+        if not mask.any():
+            return np.zeros(0), (i, t, mask, np.zeros(0), SolveStatus.DEGENERATE)
+        expected_mu = np.nan_to_num(mu_row[mask])
+        sig_status = _SolvePrimitivesMixin._check_signal(mu_row, mask)
+        if sig_status is not None:
+            return expected_mu, (i, t, mask, np.zeros_like(expected_mu), sig_status)
+        return expected_mu, None
+
+    @staticmethod
+    def _denom_guard_yield(
+        i: int,
+        t: datetime.date,
+        mask: np.ndarray,
+        expected_mu: np.ndarray,
+        pos_raw: np.ndarray,
+        denom: float,
+        denom_tol: float,
+    ) -> SolveYield:
+        """Apply the normalisation-denominator guard and return the appropriate yield tuple.
+
+        Emits a `WARNING` and returns a
+        `DEGENERATE` yield when *denom* is non-finite or at
+        or below *denom_tol*; otherwise returns a `VALID`
+        yield with normalised positions ``pos_raw / denom``.
+
+        Args:
+            i: Row index.
+            t: Timestamp.
+            mask: Boolean asset mask of shape ``(n_assets,)``.
+            expected_mu: Masked expected-return vector of shape ``(n_active,)``.
+            pos_raw: Raw (pre-normalisation) position vector of shape ``(n_active,)``.
+            denom: Computed normalisation denominator.
+            denom_tol: Tolerance threshold below which *denom* is treated as degenerate.
+
+        Returns:
+            SolveYield: Either a degenerate or valid ``(i, t, mask, pos, status)`` tuple.
+        """
+        n_active = len(expected_mu)
+        if not np.isfinite(denom) or denom <= denom_tol:
+            _logger.warning(
+                "Positions zeroed at t=%s: normalisation denominator is degenerate "
+                "(denom=%s, denom_tol=%s). Check signal magnitude and covariance matrix.",
+                t,
+                denom,
+                denom_tol,
+                extra={
+                    "context": {
+                        "t": str(t),
+                        "denom": denom,
+                        "denom_tol": denom_tol,
+                    }
+                },
+            )
+            return i, t, mask, np.zeros(n_active), SolveStatus.DEGENERATE
+        return i, t, mask, pos_raw / denom, SolveStatus.VALID
+
+    @staticmethod
+    def _apply_turnover_constraint(
+        new_cash: np.ndarray,
+        prev_cash: np.ndarray,
+        max_turnover: float,
+    ) -> np.ndarray:
+        """Cap the L1 norm of the position change to *max_turnover*.
+
+        When ``sum(|new_cash - prev_cash|) > max_turnover``, the delta is
+        scaled back proportionally toward *prev_cash* so that the constraint
+        is exactly met.  When the constraint is already satisfied the input is
+        returned unchanged.
+
+        Args:
+            new_cash: Proposed cash positions after the solve step, shape
+                ``(n_active,)`` — ``NaN`` values treated as zero.
+            prev_cash: Cash positions at the previous step, shape
+                ``(n_active,)`` — ``NaN`` values treated as zero.
+            max_turnover: Maximum allowed L1 norm of the position change.
+
+        Returns:
+            np.ndarray: The (possibly scaled) new cash positions.
+        """
+        curr = np.nan_to_num(new_cash, nan=0.0)
+        prev = np.nan_to_num(prev_cash, nan=0.0)
+        delta = curr - prev
+        total_delta = float(np.sum(np.abs(delta)))
+        if total_delta > max_turnover:
+            scale = max_turnover / total_delta
+            return cast("np.ndarray", prev + delta * scale)
+        return new_cash
+
+    @staticmethod
+    def _sliding_warmup_or_degenerate(
+        i: int,
+        t: datetime.date,
+        mask: np.ndarray,
+        win_w: int,
+    ) -> SolveYield:
+        """Classify a no-matrix sliding-window row as WARMUP or DEGENERATE.
+
+        Distinguishes an insufficient-history warm-up row (mask non-empty but
+        fewer than ``win_w`` rows seen) from a genuine no-data / model-failure
+        row, which is zeroed and marked degenerate.
+        """
+        if mask.any() and i + 1 < win_w:
+            return i, t, mask, None, SolveStatus.WARMUP
+        return i, t, mask, np.zeros(int(mask.sum())), SolveStatus.DEGENERATE

--- a/src/basanos/math/_engine_validation.py
+++ b/src/basanos/math/_engine_validation.py
@@ -1,0 +1,132 @@
+"""Input validation for `BasanosEngine`.
+
+Extracted from ``optimizer.py`` so the engine facade stays focused on the
+core position-solving logic.  Every name defined here is re-exported from
+``optimizer`` so existing callers (and tests that import ``_validate_inputs`` /
+``_validate_null_fraction`` from ``basanos.math.optimizer``) are unaffected.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import polars as pl
+
+from ..exceptions import (
+    ColumnMismatchError,
+    ExcessiveNullsError,
+    MissingDateColumnError,
+    MonotonicPricesError,
+    NonPositivePricesError,
+    ShapeMismatchError,
+)
+from ._config import BasanosConfig, CovarianceMode
+
+_logger = logging.getLogger(__name__)
+
+
+def _validate_required_date_columns(prices: pl.DataFrame, mu: pl.DataFrame) -> None:
+    """Ensure both input frames expose the required ``date`` column."""
+    if "date" not in prices.columns:
+        raise MissingDateColumnError("prices")
+    if "date" not in mu.columns:
+        raise MissingDateColumnError("mu")
+
+
+def _validate_shape_and_column_sets(prices: pl.DataFrame, mu: pl.DataFrame) -> None:
+    """Ensure prices and signals are shape- and schema-compatible."""
+    if prices.shape != mu.shape:
+        raise ShapeMismatchError(prices.shape, mu.shape)
+    if not set(prices.columns) == set(mu.columns):
+        raise ColumnMismatchError(prices.columns, mu.columns)
+
+
+def _numeric_assets(prices: pl.DataFrame) -> list[str]:
+    """Return numeric asset columns, excluding the ``date`` column."""
+    return [c for c in prices.columns if c != "date" and prices[c].dtype.is_numeric()]
+
+
+def _validate_positive_prices(prices: pl.DataFrame, assets: list[str]) -> None:
+    """Ensure all finite/non-null prices are strictly positive."""
+    for asset in assets:
+        col = prices[asset].drop_nulls()
+        if col.len() > 0 and (col <= 0).any():
+            raise NonPositivePricesError(asset)
+
+
+def _validate_null_fraction(prices: pl.DataFrame, assets: list[str], max_nan_fraction: float) -> None:
+    """Reject asset columns whose null fraction exceeds configuration bounds."""
+    n_rows = prices.height
+    if n_rows == 0:
+        return
+    for asset in assets:
+        nan_frac = prices[asset].null_count() / n_rows
+        if nan_frac > max_nan_fraction:
+            raise ExcessiveNullsError(asset, nan_frac, max_nan_fraction)
+
+
+def _validate_non_monotonic_prices(prices: pl.DataFrame, assets: list[str]) -> None:
+    """Reject monotonic asset series that indicate malformed synthetic data."""
+    for asset in assets:
+        col = prices[asset].drop_nulls()
+        if col.len() > 2:
+            diffs = col.diff().drop_nulls()
+            if (diffs >= 0).all() or (diffs <= 0).all():
+                raise MonotonicPricesError(asset)
+
+
+def _warn_short_sliding_window_data(prices: pl.DataFrame, cfg: BasanosConfig) -> None:
+    """Emit a warning when data is too short relative to the configured SW window."""
+    if cfg.covariance_mode == CovarianceMode.sliding_window and cfg.window is not None:
+        n_rows = prices.height
+        w: int = cfg.window
+        if n_rows < 2 * w:
+            _logger.warning(
+                "Dataset length (%d rows) is less than 2 * window (%d). "
+                "The first %d timestamps will yield zero positions during warm-up; "
+                "consider using a longer history or reducing 'window'.",
+                n_rows,
+                2 * w,
+                w - 1,
+            )
+
+
+def _validate_inputs(prices: pl.DataFrame, mu: pl.DataFrame, cfg: BasanosConfig) -> None:
+    """Validate ``prices``, ``mu``, and ``cfg`` for use with `BasanosEngine`.
+
+    Checks that both DataFrames contain a ``'date'`` column, share identical
+    shapes and column sets, contain no non-positive prices, no excessive NaN
+    fractions, and no monotonically non-varying price series.  Also emits a
+    warning when the dataset is too short relative to a configured
+    sliding-window size.
+
+    Args:
+        prices: DataFrame of price levels per asset over time.
+        mu: DataFrame of expected-return signals aligned with ``prices``.
+        cfg: Engine configuration instance.
+
+    Raises:
+        MissingDateColumnError: If ``'date'`` is absent from either frame.
+        ShapeMismatchError: If ``prices`` and ``mu`` have different shapes.
+        ColumnMismatchError: If the column sets of the two frames differ.
+        NonPositivePricesError: If any asset contains a non-positive price.
+        ExcessiveNullsError: If any asset column exceeds ``cfg.max_nan_fraction``.
+        MonotonicPricesError: If any asset price series is monotonically
+            non-decreasing or non-increasing.
+
+    Warns:
+        UserWarning (via logging): If ``cfg.covariance`` is a
+            `SlidingWindowConfig` and
+            ``len(prices) < 2 * cfg.covariance.window``, a warning is emitted
+            via the module logger rather than an exception.  This is a
+            deliberate soft boundary — callers may intentionally supply data
+            shorter than the full warm-up period.  During warm-up the first
+            ``window - 1`` timestamps will yield zero positions.
+    """
+    _validate_required_date_columns(prices, mu)
+    _validate_shape_and_column_sets(prices, mu)
+    assets = _numeric_assets(prices)
+    _validate_positive_prices(prices, assets)
+    _validate_null_fraction(prices, assets, cfg.max_nan_fraction)
+    _validate_non_monotonic_prices(prices, assets)
+    _warn_short_sliding_window_data(prices, cfg)

--- a/src/basanos/math/_stream.py
+++ b/src/basanos/math/_stream.py
@@ -275,6 +275,22 @@ class BasanosStream:
             vola=np.full(n_assets, np.nan),
         )
 
+    @staticmethod
+    def _apply_step_turnover(
+        cfg: BasanosConfig,
+        status: SolveStatus,
+        new_cash_pos: np.ndarray,
+        mask: np.ndarray,
+        prev_cash_pos: np.ndarray,
+    ) -> None:
+        """Cap the active-asset position change in place when a turnover limit is set."""
+        if cfg.max_turnover is not None and status == SolveStatus.VALID:
+            new_cash_pos[mask] = _SolveMixin._apply_turnover_constraint(
+                new_cash_pos[mask],
+                prev_cash_pos[mask],
+                cfg.max_turnover,
+            )
+
     def step(
         self,
         new_prices: np.ndarray | dict[str, float],
@@ -430,12 +446,7 @@ class BasanosStream:
             )
 
         # ── Apply turnover constraint ─────────────────────────────────────────
-        if cfg.max_turnover is not None and status == SolveStatus.VALID:
-            new_cash_pos[mask] = _SolveMixin._apply_turnover_constraint(
-                new_cash_pos[mask],
-                state.prev_cash_pos[mask],
-                cfg.max_turnover,
-            )
+        self._apply_step_turnover(cfg, status, new_cash_pos, mask, state.prev_cash_pos)
 
         # ── Persist updated state ───────────────────────────────────────────
         state.persist(

--- a/src/basanos/math/_stream_io.py
+++ b/src/basanos/math/_stream_io.py
@@ -65,6 +65,32 @@ def save_stream_archive(
     )
 
 
+def _validate_archive_version(data: Any) -> None:
+    """Raise if *data* lacks a format tag or has an incompatible version."""
+    if "format_version" not in data:
+        raise ValueError(  # noqa: TRY003
+            "Stream file is missing a format version tag. "
+            "It was written with an incompatible version of BasanosStream. "
+            "Re-generate it via BasanosStream.from_warmup()."
+        )
+    found = int(data["format_version"])
+    if found != _SAVE_FORMAT_VERSION:
+        raise ValueError(  # noqa: TRY003
+            f"Stream file was written with format version {found}, "
+            f"but the current version is {_SAVE_FORMAT_VERSION}. "
+            "Re-generate it via BasanosStream.from_warmup()."
+        )
+
+
+def _state_field_from_archive(field_name: str, raw: Any) -> Any:
+    """Deserialise a single `_StreamState` field from its archive representation."""
+    if field_name in ("sw_ret_buf", "corr_ret_buf"):
+        return raw if raw.size > 0 else None
+    if field_name == "step_count":
+        return int(raw)
+    return raw
+
+
 def load_stream_archive(
     path: str | os.PathLike[str],
 ) -> tuple[BasanosConfig, list[str], _StreamState]:
@@ -83,19 +109,7 @@ def load_stream_archive(
         StreamStateCorruptError: If a required key is absent from the archive.
     """
     with np.load(path, allow_pickle=False) as data:
-        if "format_version" not in data:
-            raise ValueError(  # noqa: TRY003
-                "Stream file is missing a format version tag. "
-                "It was written with an incompatible version of BasanosStream. "
-                "Re-generate it via BasanosStream.from_warmup()."
-            )
-        found = int(data["format_version"])
-        if found != _SAVE_FORMAT_VERSION:
-            raise ValueError(  # noqa: TRY003
-                f"Stream file was written with format version {found}, "
-                f"but the current version is {_SAVE_FORMAT_VERSION}. "
-                "Re-generate it via BasanosStream.from_warmup()."
-            )
+        _validate_archive_version(data)
         # Validate that every required key is present.  This catches archives
         # that were produced by an older codebase missing a newly added field,
         # or archives that have been manually edited, with a descriptive error
@@ -106,14 +120,9 @@ def load_stream_archive(
             raise StreamStateCorruptError(missing)
         cfg = BasanosConfig.model_validate_json(data["cfg_json"].item())
         assets: list[str] = list(data["assets"])
-        state_kwargs: dict[str, Any] = {}
-        for field in dataclasses.fields(_StreamState):
-            raw = data[field.name]
-            if field.name in ("sw_ret_buf", "corr_ret_buf"):
-                state_kwargs[field.name] = raw if raw.size > 0 else None
-            elif field.name == "step_count":
-                state_kwargs[field.name] = int(raw)
-            else:
-                state_kwargs[field.name] = raw
+        state_kwargs: dict[str, Any] = {
+            field.name: _state_field_from_archive(field.name, data[field.name])
+            for field in dataclasses.fields(_StreamState)
+        }
     state = _StreamState(**state_kwargs)
     return cfg, assets, state

--- a/src/basanos/math/_stream_solve.py
+++ b/src/basanos/math/_stream_solve.py
@@ -26,6 +26,58 @@ from ._stream_state import _StreamState
 _logger = logging.getLogger(__name__)
 
 
+def _fit_sliding_factor_model(
+    cfg: BasanosConfig,
+    state: _StreamState,
+    mask: np.ndarray,
+    date: Any,
+) -> FactorModel | None:
+    """Fit a truncated factor model on the masked rolling window; ``None`` on SVD failure."""
+    sw_config = cast(SlidingWindowConfig, cfg.covariance_config)
+    sw_ret_buf = cast(np.ndarray, state.sw_ret_buf)
+    window_ret = np.where(
+        np.isfinite(sw_ret_buf[:, mask]),
+        sw_ret_buf[:, mask],
+        0.0,
+    )
+    n_sub = int(mask.sum())
+    k_eff = min(sw_config.n_factors, sw_config.window, n_sub)
+    if sw_config.max_components is not None:
+        k_eff = min(k_eff, sw_config.max_components)
+    try:
+        return FactorModel.from_returns(window_ret, k=k_eff)
+    except (np.linalg.LinAlgError, ValueError) as exc:
+        _logger.debug("Sliding window SVD failed at date=%s: %s", date, exc)
+        return None
+
+
+def _woodbury_normalised(
+    fm: FactorModel,
+    expected_mu: np.ndarray,
+    cfg: BasanosConfig,
+    date: Any,
+) -> np.ndarray | None:
+    """Woodbury-solve and normalise; ``None`` on solve failure or degenerate denominator."""
+    try:
+        x = fm.solve(expected_mu)
+        denom_val = float(np.sqrt(max(0.0, float(np.dot(expected_mu, x)))))
+    except (SingularMatrixError, np.linalg.LinAlgError) as exc:
+        _logger.warning("Woodbury solve failed at date=%s: %s", date, exc)
+        return None
+
+    if not np.isfinite(denom_val) or denom_val <= cfg.denom_tol:
+        _logger.warning(
+            "Positions zeroed at date=%s (sliding_window): normalisation "
+            "denominator degenerate (denom=%s, denom_tol=%s).",
+            date,
+            denom_val,
+            cfg.denom_tol,
+        )
+        return None
+
+    return cast("np.ndarray", x / denom_val)
+
+
 def solve_sliding_window_position(
     *,
     cfg: BasanosConfig,
@@ -39,26 +91,11 @@ def solve_sliding_window_position(
     """Solve one step in SlidingWindow mode and return cash position + status."""
     new_cash_pos = np.full(n_assets, np.nan, dtype=float)
     status = SolveStatus.DEGENERATE
-    sw_config = cast(SlidingWindowConfig, cfg.covariance_config)
     if not mask.any():
         return new_cash_pos, status
 
-    win_w = sw_config.window
-    win_k = sw_config.n_factors
-    sw_ret_buf = cast(np.ndarray, state.sw_ret_buf)
-    window_ret = np.where(
-        np.isfinite(sw_ret_buf[:, mask]),
-        sw_ret_buf[:, mask],
-        0.0,
-    )
-    n_sub = int(mask.sum())
-    k_eff = min(win_k, win_w, n_sub)
-    if sw_config.max_components is not None:
-        k_eff = min(k_eff, sw_config.max_components)
-    try:
-        fm = FactorModel.from_returns(window_ret, k=k_eff)
-    except (np.linalg.LinAlgError, ValueError) as exc:
-        _logger.debug("Sliding window SVD failed at date=%s: %s", date, exc)
+    fm = _fit_sliding_factor_model(cfg, state, mask, date)
+    if fm is None:
         new_cash_pos[mask] = 0.0
         return new_cash_pos, status
 
@@ -67,29 +104,13 @@ def solve_sliding_window_position(
         new_cash_pos[mask] = 0.0
         return new_cash_pos, SolveStatus.ZERO_SIGNAL
 
-    try:
-        x = fm.solve(expected_mu)
-        denom_val = float(np.sqrt(max(0.0, float(np.dot(expected_mu, x)))))
-    except (SingularMatrixError, np.linalg.LinAlgError) as exc:
-        _logger.warning("Woodbury solve failed at date=%s: %s", date, exc)
+    risk_pos = _woodbury_normalised(fm, expected_mu, cfg, date)
+    if risk_pos is None:
         new_cash_pos[mask] = 0.0
         return new_cash_pos, status
 
-    if not np.isfinite(denom_val) or denom_val <= cfg.denom_tol:
-        _logger.warning(
-            "Positions zeroed at date=%s (sliding_window): normalisation "
-            "denominator degenerate (denom=%s, denom_tol=%s).",
-            date,
-            denom_val,
-            cfg.denom_tol,
-        )
-        new_cash_pos[mask] = 0.0
-        return new_cash_pos, status
-
-    risk_pos = x / denom_val
-    vola_sub = vola_vec[mask]
     with np.errstate(invalid="ignore"):
-        new_cash_pos[mask] = risk_pos / vola_sub
+        new_cash_pos[mask] = risk_pos / vola_vec[mask]
     return new_cash_pos, SolveStatus.VALID
 
 

--- a/src/basanos/math/optimizer.py
+++ b/src/basanos/math/optimizer.py
@@ -65,12 +65,20 @@ readable and independently testable:
 
 * `_config` — `BasanosConfig` and all
   covariance-mode configuration classes.
+* `_engine_validation` — free functions that validate the
+  ``prices`` / ``mu`` / ``cfg`` inputs (re-exported here).
+* `_engine_core` — the `_CoreDataMixin` providing the
+  core data-access properties (``assets``, ``ret_adj``, ``vola``, ``cor``,
+  ``cor_tensor``).
 * `_engine_solve` — private helpers providing the
   ``_iter_matrices`` and ``_iter_solve`` generators (per-timestamp solve
   logic).
 * `_engine_diagnostics` — private helpers providing
   matrix-quality diagnostics (condition number, effective rank, solver
   residual, signal utilisation).
+* `_engine_performance` — the `_PerformanceMixin` providing the
+  portfolio-Sharpe sweep helpers (``sharpe_at_shrink``,
+  ``sharpe_at_window_factors``, ``naive_sharpe``).
 * `_engine_ic` — private helpers providing signal
   evaluation metrics (IC, Rank IC, ICIR, and summary statistics).
 * This module — `BasanosEngine`, a single flat class that wires
@@ -78,23 +86,11 @@ readable and independently testable:
 """
 
 import dataclasses
-import datetime
-import logging
 
 import numpy as np
 import polars as pl
-from cvx.linalg import cov_to_corr
-from cvx.linalg.covariance.ewm_cov import ewm_covariance
 from jquantstats import Portfolio
 
-from ..exceptions import (
-    ColumnMismatchError,
-    ExcessiveNullsError,
-    MissingDateColumnError,
-    MonotonicPricesError,
-    NonPositivePricesError,
-    ShapeMismatchError,
-)
 from ._config import (
     BasanosConfig,
     CovarianceConfig,
@@ -103,120 +99,19 @@ from ._config import (
     SlidingWindowConfig,
 )
 from ._config_report import ConfigReport
+from ._engine_core import _CoreDataMixin as _CoreDataMixin
 from ._engine_diagnostics import _DiagnosticsMixin as _DiagnosticsMixin
 from ._engine_ic import _SignalEvaluatorMixin as _SignalEvaluatorMixin
+from ._engine_performance import _PerformanceMixin as _PerformanceMixin
 from ._engine_solve import _SolveMixin as _SolveMixin
-from ._signal import vol_adj
-
-_logger = logging.getLogger(__name__)
-
-
-def _validate_required_date_columns(prices: pl.DataFrame, mu: pl.DataFrame) -> None:
-    """Ensure both input frames expose the required ``date`` column."""
-    if "date" not in prices.columns:
-        raise MissingDateColumnError("prices")
-    if "date" not in mu.columns:
-        raise MissingDateColumnError("mu")
-
-
-def _validate_shape_and_column_sets(prices: pl.DataFrame, mu: pl.DataFrame) -> None:
-    """Ensure prices and signals are shape- and schema-compatible."""
-    if prices.shape != mu.shape:
-        raise ShapeMismatchError(prices.shape, mu.shape)
-    if not set(prices.columns) == set(mu.columns):
-        raise ColumnMismatchError(prices.columns, mu.columns)
-
-
-def _numeric_assets(prices: pl.DataFrame) -> list[str]:
-    """Return numeric asset columns, excluding the ``date`` column."""
-    return [c for c in prices.columns if c != "date" and prices[c].dtype.is_numeric()]
-
-
-def _validate_positive_prices(prices: pl.DataFrame, assets: list[str]) -> None:
-    """Ensure all finite/non-null prices are strictly positive."""
-    for asset in assets:
-        col = prices[asset].drop_nulls()
-        if col.len() > 0 and (col <= 0).any():
-            raise NonPositivePricesError(asset)
-
-
-def _validate_null_fraction(prices: pl.DataFrame, assets: list[str], max_nan_fraction: float) -> None:
-    """Reject asset columns whose null fraction exceeds configuration bounds."""
-    n_rows = prices.height
-    if n_rows == 0:
-        return
-    for asset in assets:
-        nan_frac = prices[asset].null_count() / n_rows
-        if nan_frac > max_nan_fraction:
-            raise ExcessiveNullsError(asset, nan_frac, max_nan_fraction)
-
-
-def _validate_non_monotonic_prices(prices: pl.DataFrame, assets: list[str]) -> None:
-    """Reject monotonic asset series that indicate malformed synthetic data."""
-    for asset in assets:
-        col = prices[asset].drop_nulls()
-        if col.len() > 2:
-            diffs = col.diff().drop_nulls()
-            if (diffs >= 0).all() or (diffs <= 0).all():
-                raise MonotonicPricesError(asset)
-
-
-def _warn_short_sliding_window_data(prices: pl.DataFrame, cfg: "BasanosConfig") -> None:
-    """Emit a warning when data is too short relative to the configured SW window."""
-    if cfg.covariance_mode == CovarianceMode.sliding_window and cfg.window is not None:
-        n_rows = prices.height
-        w: int = cfg.window
-        if n_rows < 2 * w:
-            _logger.warning(
-                "Dataset length (%d rows) is less than 2 * window (%d). "
-                "The first %d timestamps will yield zero positions during warm-up; "
-                "consider using a longer history or reducing 'window'.",
-                n_rows,
-                2 * w,
-                w - 1,
-            )
-
-
-def _validate_inputs(prices: pl.DataFrame, mu: pl.DataFrame, cfg: "BasanosConfig") -> None:
-    """Validate ``prices``, ``mu``, and ``cfg`` for use with `BasanosEngine`.
-
-    Checks that both DataFrames contain a ``'date'`` column, share identical
-    shapes and column sets, contain no non-positive prices, no excessive NaN
-    fractions, and no monotonically non-varying price series.  Also emits a
-    warning when the dataset is too short relative to a configured
-    sliding-window size.
-
-    Args:
-        prices: DataFrame of price levels per asset over time.
-        mu: DataFrame of expected-return signals aligned with ``prices``.
-        cfg: Engine configuration instance.
-
-    Raises:
-        MissingDateColumnError: If ``'date'`` is absent from either frame.
-        ShapeMismatchError: If ``prices`` and ``mu`` have different shapes.
-        ColumnMismatchError: If the column sets of the two frames differ.
-        NonPositivePricesError: If any asset contains a non-positive price.
-        ExcessiveNullsError: If any asset column exceeds ``cfg.max_nan_fraction``.
-        MonotonicPricesError: If any asset price series is monotonically
-            non-decreasing or non-increasing.
-
-    Warns:
-        UserWarning (via logging): If ``cfg.covariance`` is a
-            `SlidingWindowConfig` and
-            ``len(prices) < 2 * cfg.covariance.window``, a warning is emitted
-            via the module logger rather than an exception.  This is a
-            deliberate soft boundary — callers may intentionally supply data
-            shorter than the full warm-up period.  During warm-up the first
-            ``window - 1`` timestamps will yield zero positions.
-    """
-    _validate_required_date_columns(prices, mu)
-    _validate_shape_and_column_sets(prices, mu)
-    assets = _numeric_assets(prices)
-    _validate_positive_prices(prices, assets)
-    _validate_null_fraction(prices, assets, cfg.max_nan_fraction)
-    _validate_non_monotonic_prices(prices, assets)
-    _warn_short_sliding_window_data(prices, cfg)
-
+from ._engine_validation import _numeric_assets as _numeric_assets
+from ._engine_validation import _validate_inputs as _validate_inputs
+from ._engine_validation import _validate_non_monotonic_prices as _validate_non_monotonic_prices
+from ._engine_validation import _validate_null_fraction as _validate_null_fraction
+from ._engine_validation import _validate_positive_prices as _validate_positive_prices
+from ._engine_validation import _validate_required_date_columns as _validate_required_date_columns
+from ._engine_validation import _validate_shape_and_column_sets as _validate_shape_and_column_sets
+from ._engine_validation import _warn_short_sliding_window_data as _warn_short_sliding_window_data
 
 # ---------------------------------------------------------------------------
 # Re-export config symbols so ``from basanos.math.optimizer import …`` keeps
@@ -233,7 +128,7 @@ __all__ = [
 
 
 @dataclasses.dataclass(frozen=True)
-class BasanosEngine(_DiagnosticsMixin, _SignalEvaluatorMixin, _SolveMixin):
+class BasanosEngine(_CoreDataMixin, _DiagnosticsMixin, _PerformanceMixin, _SignalEvaluatorMixin, _SolveMixin):
     """Engine to compute correlation matrices and optimize risk positions.
 
     Encapsulates price data and configuration to build EWM-based
@@ -328,112 +223,10 @@ class BasanosEngine(_DiagnosticsMixin, _SignalEvaluatorMixin, _SolveMixin):
         _validate_inputs(self.prices, self.mu, self.cfg)
 
     # ------------------------------------------------------------------
-    # Core data-access properties
+    # Core data-access properties — inherited from _CoreDataMixin
     # ------------------------------------------------------------------
-
-    @property
-    def assets(self) -> list[str]:
-        """List asset column names (numeric columns excluding 'date')."""
-        return [c for c in self.prices.columns if c != "date" and self.prices[c].dtype.is_numeric()]
-
-    @property
-    def ret_adj(self) -> pl.DataFrame:
-        """Return per-asset volatility-adjusted log returns clipped by cfg.clip.
-
-        Uses an EWMA volatility estimate with lookback ``cfg.vola`` to
-        standardize log returns for each numeric asset column.
-        """
-        return self.prices.with_columns(
-            [vol_adj(pl.col(asset), vola=self.cfg.vola, clip=self.cfg.clip) for asset in self.assets]
-        )
-
-    @property
-    def vola(self) -> pl.DataFrame:
-        """Per-asset EWMA volatility of percentage returns.
-
-        Computes percent changes for each numeric asset column and applies an
-        exponentially weighted standard deviation using the lookback specified
-        by ``cfg.vola``. The result is a DataFrame aligned with ``self.prices``
-        whose numeric columns hold per-asset volatility estimates.
-        """
-        return self.prices.with_columns(
-            pl.col(asset)
-            .pct_change()
-            .ewm_std(com=self.cfg.vola - 1, adjust=True, min_samples=self.cfg.vola)
-            .alias(asset)
-            for asset in self.assets
-        )
-
-    @property
-    def cor(self) -> dict[datetime.date, np.ndarray]:
-        """Compute per-timestamp EWM correlation matrices.
-
-        Builds volatility-adjusted returns for all assets, computes an
-        exponentially weighted correlation using a pure NumPy implementation
-        (with window ``cfg.corr``), and returns a mapping from each timestamp
-        to the corresponding correlation matrix as a NumPy array.
-
-        Returns:
-            dict: Mapping ``date -> np.ndarray`` of shape (n_assets, n_assets).
-
-        Performance:
-            Delegates to ``ewm_covariance`` from ``cvx.linalg``.
-            For large *N* or *T*, prefer ``cor_tensor`` to keep a single
-            contiguous array rather than building a Python dict.
-        """
-        assets = list(self.assets)
-        n = len(assets)
-        span = 2 * self.cfg.corr + 1
-        cov_dict = ewm_covariance(
-            self.ret_adj,
-            assets=assets,
-            index_col="date",
-            window=span,
-            warmup=self.cfg.corr,
-        )
-        nan_mat = np.full((n, n), np.nan)
-        return {
-            date: cov_to_corr(cov_dict[date], self.cfg.min_corr_denom) if date in cov_dict else nan_mat.copy()
-            for date in self.prices["date"].to_list()
-        }
-
-    @property
-    def cor_tensor(self) -> np.ndarray:
-        """Return all correlation matrices stacked as a 3-D tensor.
-
-        Converts the per-timestamp correlation dict (see `cor`) into a
-        single contiguous NumPy array so that the full history can be saved to
-        a flat ``.npy`` file with `save` and reloaded with
-        `load`.
-
-        Returns:
-            np.ndarray: Array of shape ``(T, N, N)`` where *T* is the number of
-            timestamps and *N* the number of assets.  ``tensor[t]`` is the
-            correlation matrix for the *t*-th date (same ordering as
-            ``self.prices["date"]``).
-
-        Examples:
-            >>> import tempfile, pathlib
-            >>> import numpy as np
-            >>> import polars as pl
-            >>> from basanos.math.optimizer import BasanosConfig, BasanosEngine
-            >>> dates = pl.Series("date", list(range(100)))
-            >>> rng0 = np.random.default_rng(0).lognormal(size=100)
-            >>> rng1 = np.random.default_rng(1).lognormal(size=100)
-            >>> prices = pl.DataFrame({"date": dates, "A": rng0, "B": rng1})
-            >>> rng2 = np.random.default_rng(2).normal(size=100)
-            >>> rng3 = np.random.default_rng(3).normal(size=100)
-            >>> mu = pl.DataFrame({"date": dates, "A": rng2, "B": rng3})
-            >>> cfg = BasanosConfig(vola=10, corr=20, clip=3.0, shrink=0.5, aum=1e6)
-            >>> engine = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
-            >>> tensor = engine.cor_tensor
-            >>> with tempfile.TemporaryDirectory() as td:
-            ...     path = pathlib.Path(td) / "cor.npy"
-            ...     np.save(path, tensor)
-            ...     loaded = np.load(path)
-            >>> np.testing.assert_array_equal(tensor, loaded)
-        """
-        return np.stack(list(self.cor.values()), axis=0)
+    # (assets, ret_adj, vola, cor, cor_tensor)
+    # Implementations live in _engine_core.py.
 
     # ------------------------------------------------------------------
     # Internal solve helpers — inherited from _SolveMixin
@@ -595,144 +388,11 @@ class BasanosEngine(_DiagnosticsMixin, _SignalEvaluatorMixin, _SolveMixin):
         scaled = cp.with_columns(pl.col(a) * self.cfg.position_scale for a in assets)
         return Portfolio.from_cash_position(self.prices, scaled, aum=self.cfg.aum, cost_per_unit=self.cfg.cost_per_unit)
 
-    def sharpe_at_shrink(self, shrink: float) -> float:
-        r"""Return the annualised portfolio Sharpe ratio for the given shrinkage weight.
-
-        Constructs a new `BasanosEngine` with all parameters identical to
-        ``self`` except that ``cfg.shrink`` is replaced by ``shrink``, then
-        returns the annualised Sharpe ratio of the resulting portfolio.
-
-        This is the canonical single-argument callable required by the benchmarks
-        specification: ``f(λ) → Sharpe``.  Use it to sweep λ across ``[0, 1]``
-        and measure whether correlation adjustment adds value over the
-        signal-proportional baseline (λ = 0) or the unregularised limit (λ = 1).
-
-        Corner cases:
-            * **λ = 0** — the shrunk matrix equals the identity, so the
-              optimiser treats all assets as uncorrelated and positions are
-              purely signal-proportional (no correlation adjustment).
-            * **λ = 1** — the raw EWMA correlation matrix is used without
-              shrinkage.
-
-        Args:
-            shrink: Retention weight λ ∈ [0, 1].  See
-                `shrink` for full documentation.
-
-        Returns:
-            Annualised Sharpe ratio of the portfolio returns as a ``float``.
-            Returns ``float("nan")`` when the Sharpe ratio cannot be computed
-            (e.g. zero-variance returns).
-
-        Raises:
-            ValidationError: When ``shrink`` is outside [0, 1] (delegated to
-                `BasanosConfig` field validation).
-
-        Examples:
-            >>> import numpy as np
-            >>> import polars as pl
-            >>> from basanos.math.optimizer import BasanosConfig, BasanosEngine
-            >>> dates = pl.Series("date", list(range(200)))
-            >>> rng = np.random.default_rng(0)
-            >>> prices = pl.DataFrame({"date": dates, "A": rng.lognormal(size=200), "B": rng.lognormal(size=200)})
-            >>> mu = pl.DataFrame({"date": dates, "A": rng.normal(size=200), "B": rng.normal(size=200)})
-            >>> cfg = BasanosConfig(vola=10, corr=20, clip=3.0, shrink=0.5, aum=1e6)
-            >>> engine = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
-            >>> s = engine.sharpe_at_shrink(0.5)
-            >>> isinstance(s, float)
-            True
-        """
-        new_cfg = self.cfg.replace(shrink=shrink)
-        engine = BasanosEngine(prices=self.prices, mu=self.mu, cfg=new_cfg)
-        return float(engine.portfolio.stats.sharpe().get("returns") or float("nan"))
-
-    def sharpe_at_window_factors(self, window: int, n_factors: int) -> float:
-        r"""Return the annualised portfolio Sharpe ratio for the given sliding-window parameters.
-
-        Constructs a new `BasanosEngine` with ``covariance_mode`` set to
-        ``"sliding_window"`` and the supplied ``window`` / ``n_factors``, keeping
-        all other configuration identical to ``self``.
-
-        Use this method to sweep ``(W, k)`` and compare the sliding-window
-        estimator against the EWMA baseline (via `sharpe_at_shrink`).
-
-        Args:
-            window: Rolling window length $W \geq 1$.
-                Rule of thumb: $W \geq 2 \cdot n_{\text{assets}}$.
-            n_factors: Number of latent factors $k \geq 1$.
-
-        Returns:
-            Annualised Sharpe ratio of the portfolio returns as a ``float``.
-            Returns ``float("nan")`` when the Sharpe ratio cannot be computed
-            (e.g. not enough history to fill the first window).
-
-        Raises:
-            ValidationError: When ``window`` or ``n_factors`` fail field
-                constraints (delegated to `BasanosConfig`).
-
-        Examples:
-            >>> import numpy as np
-            >>> import polars as pl
-            >>> from basanos.math.optimizer import BasanosConfig, BasanosEngine
-            >>> dates = pl.Series("date", list(range(200)))
-            >>> rng = np.random.default_rng(0)
-            >>> prices = pl.DataFrame({"date": dates, "A": rng.lognormal(size=200), "B": rng.lognormal(size=200)})
-            >>> mu = pl.DataFrame({"date": dates, "A": rng.normal(size=200), "B": rng.normal(size=200)})
-            >>> cfg = BasanosConfig(vola=10, corr=20, clip=3.0, shrink=0.5, aum=1e6)
-            >>> engine = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
-            >>> s = engine.sharpe_at_window_factors(window=40, n_factors=2)
-            >>> isinstance(s, float)
-            True
-        """
-        new_cfg = self.cfg.replace(
-            covariance_config=SlidingWindowConfig(window=window, n_factors=n_factors),
-        )
-        engine = BasanosEngine(prices=self.prices, mu=self.mu, cfg=new_cfg)
-        return float(engine.portfolio.stats.sharpe().get("returns") or float("nan"))
-
-    @property
-    def naive_sharpe(self) -> float:
-        r"""Sharpe ratio of the naïve equal-weight signal (μ = 1 for every asset/timestamp).
-
-        Replaces the expected-return signal ``mu`` with a constant matrix of
-        ones, then runs the optimiser with the current configuration and returns
-        the annualised Sharpe ratio of the resulting portfolio.
-
-        This provides the baseline answer to *"does the signal add value?"*:
-        a real signal should produce a higher Sharpe than the naïve benchmark.
-        Combined with `sharpe_at_shrink`, this yields a three-way
-        comparison:
-
-        +--------------------+----------------------------------------------+
-        | Benchmark          | What it measures                             |
-        +====================+==============================================+
-        | ``naive_sharpe``   | No signal skill; pure correlation routing   |
-        +--------------------+----------------------------------------------+
-        | ``sharpe_at_shrink(0.0)`` | Signal skill, no correlation adj.  |
-        +--------------------+----------------------------------------------+
-        | ``sharpe_at_shrink(cfg.shrink)`` | Signal + correlation adj.  |
-        +--------------------+----------------------------------------------+
-
-        Returns:
-            Annualised Sharpe ratio of the equal-weight portfolio as a ``float``.
-            Returns ``float("nan")`` when the Sharpe ratio cannot be computed.
-
-        Examples:
-            >>> import numpy as np
-            >>> import polars as pl
-            >>> from basanos.math.optimizer import BasanosConfig, BasanosEngine
-            >>> dates = pl.Series("date", list(range(200)))
-            >>> rng = np.random.default_rng(0)
-            >>> prices = pl.DataFrame({"date": dates, "A": rng.lognormal(size=200), "B": rng.lognormal(size=200)})
-            >>> mu = pl.DataFrame({"date": dates, "A": rng.normal(size=200), "B": rng.normal(size=200)})
-            >>> cfg = BasanosConfig(vola=10, corr=20, clip=3.0, shrink=0.5, aum=1e6)
-            >>> engine = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
-            >>> s = engine.naive_sharpe
-            >>> isinstance(s, float)
-            True
-        """
-        naive_mu = self.mu.with_columns(pl.lit(1.0).alias(asset) for asset in self.assets)
-        engine = BasanosEngine(prices=self.prices, mu=naive_mu, cfg=self.cfg)
-        return float(engine.portfolio.stats.sharpe().get("returns") or float("nan"))
+    # ------------------------------------------------------------------
+    # Performance sweeps — inherited from _PerformanceMixin
+    # ------------------------------------------------------------------
+    # (sharpe_at_shrink, sharpe_at_window_factors, naive_sharpe)
+    # Implementations live in _engine_performance.py.
 
     # ------------------------------------------------------------------
     # Reporting

--- a/tests/test_math/test_optimizer.py
+++ b/tests/test_math/test_optimizer.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 import math
 import pathlib
+import warnings
 from datetime import date, timedelta
 from unittest.mock import patch
 
@@ -1747,6 +1748,42 @@ class TestICNaNHandling:
         ic_vals = eng.ic()["ic"].to_list()
         # With only one valid asset pair, every IC value must be NaN
         for v in ic_vals:
+            assert v is None or (isinstance(v, float) and math.isnan(v))
+
+    def test_constant_signal_returns_nan_without_warnings(self) -> None:
+        """A constant (zero-variance) signal must yield NaN IC/rank-IC silently.
+
+        ``np.corrcoef`` and ``scipy.stats.spearmanr`` both emit warnings and
+        return NaN for constant input; the IC path short-circuits that expected
+        degenerate case, so no numpy 'invalid value encountered in divide' nor
+        scipy ``ConstantInputWarning`` must escape (regression test for #588).
+        """
+        n = 12
+        start = date(2020, 1, 1)
+        dates = pl.date_range(start=start, end=start + timedelta(days=n - 1), interval="1d", eager=True)
+        rng = np.random.default_rng(11)
+        p_a = 100.0 + np.cumsum(rng.normal(0.0, 0.5, n))
+        p_b = 200.0 + np.cumsum(rng.normal(0.0, 0.7, n))
+        prices = pl.DataFrame(
+            {"date": dates, "A": pl.Series(p_a, dtype=pl.Float64), "B": pl.Series(p_b, dtype=pl.Float64)}
+        )
+        # Both signal columns are constant → every cross-section is degenerate.
+        mu = pl.DataFrame(
+            {
+                "date": dates,
+                "A": pl.Series(np.full(n, 0.3), dtype=pl.Float64),
+                "B": pl.Series(np.full(n, 0.3), dtype=pl.Float64),
+            }
+        )
+        cfg = BasanosConfig(vola=3, corr=5, clip=3.0, shrink=0.5, aum=1e6)
+        eng = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any leaked warning fails the test
+            ic_vals = eng.ic()["ic"].to_list()
+            rank_ic_vals = eng.rank_ic()["rank_ic"].to_list()
+
+        for v in ic_vals + rank_ic_vals:
             assert v is None or (isinstance(v, float) and math.isnan(v))
 
 


### PR DESCRIPTION
Addresses the four open quality-scorecard issues. Pure refactoring / hardening — no public API changes.

## Issues closed
- Closes #588 — **IC numerical robustness.** `_engine_ic` now short-circuits constant/degenerate windows to `nan`, so `np.corrcoef` / `scipy.spearmanr` no longer emit `invalid value encountered in divide` or `ConstantInputWarning`. Covering regression test added.
- Closes #587 — **B-grade complexity.** Per-branch logic extracted into small named helpers so `uvx radon cc src -n B` returns no blocks (every function/method/class is grade A). The dual-path maintenance note in `_iter_solve` is preserved.
- Closes #586 — **optimizer.py split.** `optimizer.py` 786 → 446 LOC; cohesive pieces moved to new private modules (`_engine_validation`, `_engine_core`, `_engine_performance`, `_engine_solve_base`) and re-exported so every importable name is unchanged.
- Closes #585 — **test-layout parity.** Vendored a behaviour-aware `scripts/check_test_layout.py` (skips private modules; exempts declared cross-cutting suites) and wired `make test-layout` into the CI `test` job. Keeps the existing behaviour-grouped test organization.

## Verification
- `make test`: **709 passed, 100% coverage**, test-layout OK
- `uvx radon cc src -n B`: empty; `uvx radon mi src`: all grade A
- `make typecheck` (ty + mypy strict), `make deptry`, `make fmt` (ruff/bandit/interrogate): all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
