### PR TITLE
chore(pyproject): modernize Python version and license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 authors = [
     { name = "Thomas Schmelzer", email = "thomas.schmelzer@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
 license = "MIT"
 license-files = ["LICENSE"]
 classifiers = [
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
Modernizes the `[project]` metadata in `pyproject.toml`.

**Python versions** — one explicit trove classifier per supported version instead of the generic `Programming Language :: Python :: 3` rows. `requires-python` is 3.11", so the classifiers are: **3.11,3.12,3.13,3.14**.

**License** — dropped the `License :: ...` classifiers, which PEP 639 deprecates in favour of the `license` SPDX expression plus `license-files`. Backends implementing PEP 639 reject a project that declares both.

Metadata only — no source, dependency, or tooling changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
