### PR TITLE
chore(ci): bump the rhiza pin to v1.3.3

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.3.3
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.3.3
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.3.3
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.3.3
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.3.3
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.3.3
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.3.3
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.3.3
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.3.3
     secrets: inherit


### PR DESCRIPTION
## Why CI is red

`ci / generate-matrix` is failing here, on PRs and on `main`:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

hatchling now stamps `Metadata-Version: 2.5` into wheels. The reusable workflow at `v1.3.2` runs `build-and-inspect-python-package@v2.18.0`, whose twine 6 does not know metadata 2.5 and hard-fails. `generate-matrix` gates every other job in `(RHIZA) CI`, so nothing downstream of it ran.

Nothing in this repo changed — this is dependency drift, and it blocked the open dependabot PRs here.

## The fix

[jebel-quant/rhiza#1497](https://github.com/Jebel-Quant/rhiza/pull/1497) moved BAIPP to v3.0.1, which ships twine 7 with metadata 2.5 support, and it shipped in [v1.3.3](https://github.com/Jebel-Quant/rhiza/releases/tag/v1.3.3). This moves every `jebel-quant/rhiza/…` pin here from `v1.3.2` to `v1.3.3`.

Verified against a wheel built from this fleet: twine 6 → `InvalidDistribution`, twine 7 → `PASSED`.

v1.3.3 also carries a licence-gate fix and moves bandit's scan scope into `.bandit` so external analysers agree with CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)