### PR TITLE
fix: resolve the three /rhiza:quality findings (import cycle, README fence, test-layout opt-out)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Most systematic strategies produce a raw signal vector μ — one number per ass
 
 Basanos treats position sizing as a **linear system**:
 
-```
+```text
 C · x = μ
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,23 @@ ignore-init-method = true
 ignore-magic = true
 exclude = ["book"]
 
+[tool.check_test_layout]
+# Tests are grouped by *behaviour*, not mirrored one-to-one onto source modules:
+# a single module is often exercised by several suites (optimizer.py is covered
+# by test_optimizer.py, test_optimizer_property.py and test_optimizer_edge_cases.py),
+# and whole-pipeline suites (*_notebook, numerical regression/stability, the
+# paper-example walkthrough) map to no single source file. Parity is still
+# enforced, by scripts/check_test_layout.py via `make test-layout` (a prerequisite
+# of `make test`), and per-module coverage by the full-coverage pytest gate. This
+# table tells generic mirror-checkers not to re-derive a convention this repo does
+# not use.
+#
+# Keep the `reason` value free of literal `%` signs: radon reads every [tool.*]
+# table in this file through configparser, which treats `%` as interpolation
+# syntax and raises on a bare one.
+enforce = false
+reason = "Tests are grouped by behaviour; parity is enforced by scripts/check_test_layout.py and per-module coverage by the full-coverage pytest gate."
+
 [tool.ty.environment]
 python-version = "3.12"
 

--- a/src/basanos/math/_engine_performance.py
+++ b/src/basanos/math/_engine_performance.py
@@ -3,9 +3,14 @@
 Provides the Sharpe-ratio sweep helpers (`sharpe_at_shrink`,
 `sharpe_at_window_factors`, `naive_sharpe`) as a reusable mixin so that
 ``optimizer.py`` stays focused on the position-solving facade.  Each helper
-rebuilds a sibling engine with a modified configuration, so it constructs a new
-`BasanosEngine` via a deferred import (avoiding a circular import at module
-load time).
+rebuilds a sibling engine with a modified configuration.
+
+The sibling is built from ``type(source)`` rather than by importing
+`BasanosEngine`, so this module has **no runtime dependency on
+``optimizer.py``** — the only import of it is under ``TYPE_CHECKING``, the same
+pattern `_config_report` uses. That keeps the dependency edge one-way
+(``optimizer`` → ``_engine_performance``) instead of a cycle papered over by
+function-local imports.
 
 Classes in this module are **private implementation details**.  The public API
 is `BasanosEngine`, which inherits from `_PerformanceMixin`.
@@ -13,14 +18,48 @@ is `BasanosEngine`, which inherits from `_PerformanceMixin`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import polars as pl
 
 from ._config import SlidingWindowConfig
 
 if TYPE_CHECKING:
+    from ._config import BasanosConfig
     from ._engine_protocol import _EngineProtocol
+    from .optimizer import BasanosEngine
+
+
+def _rebuilt_sharpe(
+    source: _EngineProtocol,
+    *,
+    prices: pl.DataFrame,
+    mu: pl.DataFrame,
+    cfg: BasanosConfig,
+) -> float:
+    """Return the annualised Sharpe ratio of an engine rebuilt from *source*.
+
+    Constructs a sibling of ``source`` — same concrete class, supplied
+    ``prices`` / ``mu`` / ``cfg`` — and returns its portfolio Sharpe ratio,
+    or ``float("nan")`` when the ratio cannot be computed.
+
+    ``type(source)`` is used instead of importing `BasanosEngine`
+    directly: the concrete class is always the one that mixed this helper in, so
+    naming it at runtime would buy nothing and would make ``optimizer.py`` and
+    this module mutually dependent.
+
+    Args:
+        source: The engine whose class and identity the sibling inherits.
+        prices: Price panel for the rebuilt engine.
+        mu: Expected-return panel for the rebuilt engine.
+        cfg: Configuration for the rebuilt engine.
+
+    Returns:
+        Annualised Sharpe ratio of the rebuilt portfolio as a ``float``.
+    """
+    engine_cls = cast("type[BasanosEngine]", type(source))
+    engine = engine_cls(prices=prices, mu=mu, cfg=cfg)
+    return float(engine.portfolio.stats.sharpe().get("returns") or float("nan"))
 
 
 class _PerformanceMixin:
@@ -76,11 +115,8 @@ class _PerformanceMixin:
             >>> isinstance(s, float)
             True
         """
-        from .optimizer import BasanosEngine  # deferred to avoid a circular import
-
         new_cfg = self.cfg.replace(shrink=shrink)
-        engine = BasanosEngine(prices=self.prices, mu=self.mu, cfg=new_cfg)
-        return float(engine.portfolio.stats.sharpe().get("returns") or float("nan"))
+        return _rebuilt_sharpe(self, prices=self.prices, mu=self.mu, cfg=new_cfg)
 
     def sharpe_at_window_factors(self: _EngineProtocol, window: int, n_factors: int) -> float:
         r"""Return the annualised portfolio Sharpe ratio for the given sliding-window parameters.
@@ -120,13 +156,10 @@ class _PerformanceMixin:
             >>> isinstance(s, float)
             True
         """
-        from .optimizer import BasanosEngine  # deferred to avoid a circular import
-
         new_cfg = self.cfg.replace(
             covariance_config=SlidingWindowConfig(window=window, n_factors=n_factors),
         )
-        engine = BasanosEngine(prices=self.prices, mu=self.mu, cfg=new_cfg)
-        return float(engine.portfolio.stats.sharpe().get("returns") or float("nan"))
+        return _rebuilt_sharpe(self, prices=self.prices, mu=self.mu, cfg=new_cfg)
 
     @property
     def naive_sharpe(self: _EngineProtocol) -> float:
@@ -169,8 +202,5 @@ class _PerformanceMixin:
             >>> isinstance(s, float)
             True
         """
-        from .optimizer import BasanosEngine  # deferred to avoid a circular import
-
         naive_mu = self.mu.with_columns(pl.lit(1.0).alias(asset) for asset in self.assets)
-        engine = BasanosEngine(prices=self.prices, mu=naive_mu, cfg=self.cfg)
-        return float(engine.portfolio.stats.sharpe().get("returns") or float("nan"))
+        return _rebuilt_sharpe(self, prices=self.prices, mu=naive_mu, cfg=self.cfg)


### PR DESCRIPTION
Fixes the three findings from a `/rhiza:quality` run (full mode — all seven
template gates were passing before this PR; these were the residual deductions).

Closes #612
Closes #613
Closes #614

## `refactor(math)` — break the optimizer/_engine_performance import cycle (#612)

`optimizer.py` imported `_PerformanceMixin` at module level while
`_engine_performance.py` imported `BasanosEngine` back from inside three method
bodies, each tagged `# deferred to avoid a circular import`. It was the only
runtime import cycle left in the package — every other back-edge in
`basanos.math` is already `TYPE_CHECKING`-guarded.

The three deferred imports are replaced by a module-level `_rebuilt_sharpe`
helper that builds the sibling engine from `type(source)`. The concrete class is
always the one that mixed the helper in, so naming `BasanosEngine` at runtime
bought nothing; it now appears only under `TYPE_CHECKING` — the same pattern
`_config_report` uses — with a single `cast` carrying the typing, since
`_EngineProtocol` is not callable.

All three call sites performed the same rebuild-then-Sharpe, so that duplication
collapses into the helper too: each drops from five lines to two.

The dependency edge is one-way again: `optimizer` → `_engine_performance`.

## `docs(readme)` — tag the linear-system fence as text (#613)

The `C · x = μ` block at `README.md:40` opened an untagged fence. Nothing was
broken — the content is mathematics, not code — but an untagged fence is
invisible to every checker that walks the README. Tagging it `text` makes the
intent explicit rather than inferred.

## `chore(pyproject)` — declare the test-layout opt-out (#614)

The rationale for grouping tests by behaviour rather than mirroring source
modules lived only in the docstring of `scripts/check_test_layout.py`, where
external tooling cannot read it. Generic mirror-checkers reported 45 phantom
violations against a repo that already enforces parity — along a different axis,
with per-module coverage guaranteed by the pytest coverage gate.

`[tool.check_test_layout]` with `enforce = false` plus a reason states the
deviation where such tools look for it. Nothing about how this repo is checked
changes: `make test-layout` still runs `scripts/check_test_layout.py` unchanged,
and it remains a prerequisite of `make test`.

**One trap worth knowing about**, recorded in a comment at the table: keep the
`reason` value free of literal `%` signs. `radon` reads every `[tool.*]` table in
`pyproject.toml` through `configparser`, which treats `%` as interpolation
syntax. A first draft reading "100% pytest gate" crashed `radon cc` with
`ValueError: invalid interpolation syntax`. No repo gate catches this, because
none of them run radon.

## Verification

Every gate re-run after the changes:

| Gate | Before | After |
| --- | --- | --- |
| `make fmt` | PASS | PASS (21 hooks) |
| `make typecheck` | PASS | PASS — ty + mypy strict, 24 files |
| `make docs-coverage` | 100.0% (1181) | 100.0% (1182) |
| `make deptry` | PASS | PASS |
| `make security` | PASS | PASS |
| `make rhiza-test` | 40 passed | 40 passed |
| `make test` | 710 passed, 100.00% | 710 passed, 100.00% |
| test-layout (external checker) | exit 1, 45 violations | exit 0 |
| doc examples / README fences | 1 untagged fence | 0 violations, 0 untagged |

No new tests were needed to hold coverage: `_engine_performance.py` drops from 21
to 19 statements, and the existing tests for the three public methods exercise
the helper. Average cyclomatic complexity improves from 2.485 to 2.458, with
still zero blocks above grade A.

Scorecard: architecture 8 → 10, executable documentation 9 → 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
