### PR TITLE
chore: prune exclude entries the template no longer ships

### DIFF
--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -38,12 +38,3 @@ exclude:
   # rather than to anyone reading the tree. Upstream is where it belongs, and where it stays.
   - .github/CONFIG.md
 
-  # The discussion and issue forms: multi-field forms with required textareas, arriving at a
-  # template tag, for a repository whose issues and discussions are opened by the person who
-  # wrote the code. The friction lands entirely on the one contributor a form's structure was
-  # never meant to discipline, and a required "steps to reproduce" box is not what makes a
-  # one-line note about a covariance estimator easier to file. Both stay enabled and
-  # free-form. Recorded here rather than simply deleted, because a deletion alone is undone
-  # by the next sync.
-  - .github/DISCUSSION_TEMPLATE
-  - .github/ISSUE_TEMPLATE


### PR DESCRIPTION
Removes `exclude:` entries that no longer match anything.

The template dropped both directories in **v1.5.0**:

- `bundles/github/.github/ISSUE_TEMPLATE` — rhiza #1567 (`a34059d`)
- `bundles/github/.github/DISCUSSION_TEMPLATE` — rhiza #1566 (`20e0ffa`)

This repo is pinned at v1.5.x, so the sync never delivers those paths and the entries match nothing. `exclude:` is matched against destination paths, and an entry that resolves to nothing is silently inert — dead config that reads like an active decision.

Only `.rhiza/template.yml` is touched; no template-owned file and no repo source is in this PR. Verified with `git tag --contains`: both deletions are in v1.5.0 and v1.5.1, and `git ls-tree v1.5.1` reports 0 files for each directory.

**No gates were run.** Run `/rhiza:quality` for a scorecard.
