### PR TITLE
chore: drop the exclude entries for the retired mutation/fuzzing workflows

### DIFF
--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -18,21 +18,6 @@ templates:
 # they were never actually declined, so keeping them would be a new decision dressed up as
 # a spelling fix. Both stay synced.
 exclude:
-  # The two opt-in workflows, neither opted into here. `rhiza_mutation.yml` is gated in the
-  # caller on the repository variable MUTATION_ENABLED, so the job never starts;
-  # `rhiza_fuzzing.yml` needs FUZZING_ENABLED plus a `.clusterfuzzlite/` config this repo
-  # does not have, and its gate sits *inside* the reusable workflow, so it starts on every
-  # pull request and every push to main in order to skip -- a green check whose only
-  # content is that it had nothing to do.
-  #
-  # Declining them is a judgement about this package. basanos takes numeric arrays and a
-  # Pydantic config, with no parser and no untrusted byte stream for a fuzzer to reach; and
-  # the assertion-strength question mutation testing answers is one the coverage gate plus
-  # the Hypothesis property suites in `tests/` already answer far more cheaply than a
-  # full mutation run over the optimizer.
-  - .github/workflows/rhiza_mutation.yml
-  - .github/workflows/rhiza_fuzzing.yml
-
   # The template's PAT_TOKEN and release-secret walkthrough. It documents secrets a
   # consumer configures once in the GitHub UI, addressed to whoever set the repository up
   # rather than to anyone reading the tree. Upstream is where it belongs, and where it stays.


### PR DESCRIPTION
rhiza v1.5.0 retired `.github/workflows/rhiza_fuzzing.yml` (#1568) and `.github/workflows/rhiza_mutation.yml` (#1572), and stopped offering mutation testing in the ecosystem at all (#1492). Nothing under `bundles/` ships either path now, so excluding them declines a file the sync can no longer deliver.

This drops the two entries and the comment paragraphs that existed only to justify them. Where a comment also explained why the *other* workflow was deliberately left in the sync, that note goes too — it describes a live gate that no longer exists.

**No CI behaviour changes.** Neither workflow is delivered with or without these entries.

**This does not delete any leftover workflow file.** Orphan cleanup only considers paths recorded in `.rhiza/template.lock`'s `files:` list, and these are absent from it, so a copy still present in `.github/workflows/` stays put either way. That is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)