### PR TITLE
fix: make the test-layout opt-out's named enforcer actually run (#599)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,10 +150,16 @@ exclude = ["book"]
 # by test_optimizer.py, test_optimizer_property.py and test_optimizer_edge_cases.py),
 # and whole-pipeline suites (*_notebook, numerical regression/stability, the
 # paper-example walkthrough) map to no single source file. Parity is still
-# enforced, by scripts/check_test_layout.py via `make test-layout` (a prerequisite
-# of `make test`), and per-module coverage by the full-coverage pytest gate. This
-# table tells generic mirror-checkers not to re-derive a convention this repo does
-# not use.
+# enforced, by scripts/check_test_layout.py, and per-module coverage by the
+# full-coverage pytest gate. This table tells generic mirror-checkers not to
+# re-derive a convention this repo does not use.
+#
+# The script runs from tests/test_test_layout.py, i.e. inside the `test` gate --
+# one of the four jobs the required CI gate aggregates. It used to run from
+# `make test-layout`, a prerequisite of `make test`; rhiza v1.4 retired the synced
+# make layer and CI now invokes the gates through rhiza-task, so that target is
+# gone and a repo-local make target would not run in CI. An opt-out is only honest
+# while the mechanism it names still runs -- hence the test.
 #
 # Keep the `reason` value free of literal `%` signs: radon reads every [tool.*]
 # table in this file through configparser, which treats `%` as interpolation

--- a/scripts/check_test_layout.py
+++ b/scripts/check_test_layout.py
@@ -60,6 +60,7 @@ ALLOWED_ORPHANS: frozenset[str] = frozenset(
         "paper_example",  # reproduces the reference paper example
         "rhiza_packaging",  # template-shipped: declared vs. installed version
         "shim",  # analytics compatibility shim
+        "test_layout",  # this checker, run from tests/test_test_layout.py
     }
 )
 

--- a/tests/test_test_layout.py
+++ b/tests/test_test_layout.py
@@ -1,0 +1,34 @@
+"""Run ``scripts/check_test_layout.py`` as part of the test gate.
+
+``[tool.check_test_layout]`` in ``pyproject.toml`` opts this repo out of the
+generic ``src``/``tests`` mirror check that tooling (``/rhiza:quality``) applies,
+on the recorded grounds that parity is enforced by ``scripts/check_test_layout.py``
+instead. That opt-out is only honest while something actually runs the script.
+
+It used to be ``make test-layout``, a prerequisite of ``make test``. rhiza v1.4
+retired the synced make layer, so that target is gone and CI invokes the gates
+through ``rhiza-task`` rather than through make — a repo-local make target would
+no longer run in CI. This test is the replacement: the ``test`` gate is one of the
+four jobs the required CI gate aggregates, so a layout drift fails the build again.
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 - fixed argv, no shell, repo-local script
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+CHECKER = ROOT / "scripts" / "check_test_layout.py"
+
+
+def test_test_layout_is_clean() -> None:
+    """Every public module is tested, and every test traces back to code."""
+    result = subprocess.run(  # nosec B603 - fixed argv, shell=False
+        [sys.executable, str(CHECKER)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=ROOT,
+    )
+    assert result.returncode == 0, f"{result.stdout}{result.stderr}"


### PR DESCRIPTION
Closes #599.

## What #599 asked for, and what was left

The literal "Done when" of #599 — a `[tool.check_test_layout]` opt-out whose
`reason` names `scripts/check_test_layout.py` — was already delivered by #615.
Both checkers pass today:

```
$ python3 <rhiza-plugin>/scripts/check_test_layout.py
Test layout OK: parity not enforced by request — Tests are grouped by behaviour; …
EXIT=0
```

But the opt-out had gone stale. Its comment said parity was "enforced, by
scripts/check_test_layout.py via `make test-layout` (a prerequisite of `make
test`)". That target no longer exists:

```
$ make test-layout
unknown task: test-layout  (try `rhiza-task list`)
make: *** [test-layout] Error 2
```

rhiza v1.4 retired the synced make layer, and nothing else in the repo
referenced the script — `grep -rn check_test_layout` found only pyproject.toml
and the script itself. So the repo was suppressing a generic layout check on the
strength of a mechanism that had stopped running. An opt-out is only honest
while the thing it names still runs.

## What this changes

- **`tests/test_test_layout.py`** — runs the checker inside the `test` gate, one
  of the four jobs the required CI gate aggregates. A repo-local `local.mk`
  target would *not* have worked: CI invokes gates through `rhiza-task`, not
  through `make`.
- **`scripts/check_test_layout.py`** — registers `test_layout` in
  `ALLOWED_ORPHANS`; the new test names the checker, not a source module.
- **`pyproject.toml`** — corrects the comment to describe the live mechanism and
  records why the make target is gone.

## Verification

The gate genuinely bites — a stray `tests/test_bogus_orphan.py` fails it:

```
E  AssertionError: Test-layout check failed:
E      ✗ orphan test file tests/test_bogus_orphan.py (no source module …)
```

`make fmt`, `make typecheck`, `make test` (711 passed, 100% coverage) and
`make rhiza-test` (34 passed) are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)