### PR TITLE
chore: update rhiza to v1.7.2

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.7.2
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,9 +29,16 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.7.2
     secrets: inherit
     permissions:
       contents: read
       pages: write
       id-token: write
+    # Set `deploy-pages: false` for artifact-only mode -- the reusable workflow
+    # still uploads the generic `book` artifact, and a consumer-owned job below
+    # can download it and deploy to Cloudflare Pages, Azure Static Web Apps,
+    # S3/CloudFront, an internal web server, etc. See docs/guides/BOOK.md for a
+    # full Cloudflare Pages example.
+    # with:
+    #   deploy-pages: false

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.7.2
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.7.2
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.7.2
     secrets: inherit

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.7.2
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.7.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.7.2
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         groups: ["fast"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.16.4'
+    rev: 'v0.16.5'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]
@@ -90,7 +90,7 @@ repos:
         groups: ["security", "slow"]
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.12.6
+    rev: 0.12.9
     hooks:
       - id: uv-lock
         groups: ["python", "fast"]

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: da1e30177bebbd6fea9983bb36f5eef311e40235
+sha: 2955fe77885ad31532579eea11905f4aefb17260
 repo: jebel-quant/rhiza
 host: github
-ref: v1.7.1
+ref: v1.7.2
 include: []
 exclude:
 - .github/CONFIG.md
@@ -41,5 +41,5 @@ files:
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-08-28T17:05:03Z'
+synced_at: '2026-09-02T06:47:39Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: jebel-quant/rhiza
-ref: "v1.7.1"
+ref: "v1.7.2"
 
 profiles:
   - github-project

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Repo-specific *tasks* go in a `rhiza_task.tasks` entry point, repo-specific *targets* in
 # `local.mk`, which core deliberately does not ignore. Nothing goes below the shim: this
 # file is synced, so the next `/rhiza:update` overwrites whatever was appended to it.
-RHIZA_TASK ?= rhiza-task@1.4.1
+RHIZA_TASK ?= rhiza-task@1.5.0
 
 # uv cannot be delegated, because uv is what runs the CLI. Prepended so a machine carrying
 # an older uv still resolves the pin, exported because task bodies shell out to bare `uv`.

--- a/README.md
+++ b/README.md
@@ -105,31 +105,35 @@ dates = pl.date_range(
 )
 rng = np.random.default_rng(42)
 
-prices = pl.DataFrame({
-    "date": dates,
-    "AAPL":  100.0 + np.cumsum(rng.normal(0, 1.0, n_days)),
-    "GOOGL": 150.0 + np.cumsum(rng.normal(0, 1.2, n_days)),
-})
+prices = pl.DataFrame(
+    {
+        "date": dates,
+        "AAPL": 100.0 + np.cumsum(rng.normal(0, 1.0, n_days)),
+        "GOOGL": 150.0 + np.cumsum(rng.normal(0, 1.2, n_days)),
+    }
+)
 
 # Expected-return signals in [-1, 1] (e.g. from a forecasting model)
-mu = pl.DataFrame({
-    "date": dates,
-    "AAPL":  np.tanh(rng.normal(0, 0.5, n_days)),
-    "GOOGL": np.tanh(rng.normal(0, 0.5, n_days)),
-})
+mu = pl.DataFrame(
+    {
+        "date": dates,
+        "AAPL": np.tanh(rng.normal(0, 0.5, n_days)),
+        "GOOGL": np.tanh(rng.normal(0, 0.5, n_days)),
+    }
+)
 
 # Mode 1 — EWMA with shrinkage (default)
 cfg = BasanosConfig(
-    vola=16,    # EWMA lookback for volatility (days)
-    corr=32,    # EWMA lookback for correlation (days, must be >= vola)
-    clip=3.5,   # Clipping threshold for vol-adjusted returns
-    shrink=0.5, # Shrinkage intensity towards identity [0, 1]
-    aum=1e6,    # Assets under management
+    vola=16,  # EWMA lookback for volatility (days)
+    corr=32,  # EWMA lookback for correlation (days, must be >= vola)
+    clip=3.5,  # Clipping threshold for vol-adjusted returns
+    shrink=0.5,  # Shrinkage intensity towards identity [0, 1]
+    aum=1e6,  # Assets under management
 )
 
-engine    = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
+engine = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
 positions = engine.cash_position  # pl.DataFrame of optimized cash positions
-portfolio = engine.portfolio      # Portfolio object for analytics
+portfolio = engine.portfolio  # Portfolio object for analytics
 ```
 
 ### Factor Model Mode
@@ -149,18 +153,22 @@ dates = pl.date_range(
 )
 rng = np.random.default_rng(42)
 
-prices = pl.DataFrame({
-    "date": dates,
-    "AAPL":  100.0 + np.cumsum(rng.normal(0, 1.0, n_days)),
-    "GOOGL": 150.0 + np.cumsum(rng.normal(0, 1.2, n_days)),
-    "MSFT":  200.0 + np.cumsum(rng.normal(0, 1.5, n_days)),
-})
-mu = pl.DataFrame({
-    "date": dates,
-    "AAPL":  np.tanh(rng.normal(0, 0.5, n_days)),
-    "GOOGL": np.tanh(rng.normal(0, 0.5, n_days)),
-    "MSFT":  np.tanh(rng.normal(0, 0.5, n_days)),
-})
+prices = pl.DataFrame(
+    {
+        "date": dates,
+        "AAPL": 100.0 + np.cumsum(rng.normal(0, 1.0, n_days)),
+        "GOOGL": 150.0 + np.cumsum(rng.normal(0, 1.2, n_days)),
+        "MSFT": 200.0 + np.cumsum(rng.normal(0, 1.5, n_days)),
+    }
+)
+mu = pl.DataFrame(
+    {
+        "date": dates,
+        "AAPL": np.tanh(rng.normal(0, 0.5, n_days)),
+        "GOOGL": np.tanh(rng.normal(0, 0.5, n_days)),
+        "MSFT": np.tanh(rng.normal(0, 0.5, n_days)),
+    }
+)
 
 # Mode 2 — Sliding-window factor model (no shrinkage required)
 cfg = BasanosConfig(
@@ -170,12 +178,12 @@ cfg = BasanosConfig(
     shrink=0.5,  # only used if covariance_mode is ewma_shrink; ignored here
     aum=1e6,
     covariance_config=SlidingWindowConfig(
-        window=60,    # rolling window length W (rows); rule of thumb: W >= 2 * n_assets
+        window=60,  # rolling window length W (rows); rule of thumb: W >= 2 * n_assets
         n_factors=2,  # number of latent factors k; fewer = stronger regularisation
     ),
 )
 
-engine    = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
+engine = BasanosEngine(prices=prices, mu=mu, cfg=cfg)
 positions = engine.cash_position
 ```
 
@@ -194,36 +202,40 @@ dates = pl.date_range(
 )
 rng = np.random.default_rng(42)
 
-prices = pl.DataFrame({
-    "date": dates,
-    "AAPL":  100.0 * np.cumprod(1 + rng.normal(0.001, 0.020, n_days)),
-    "GOOGL": 150.0 * np.cumprod(1 + rng.normal(0.001, 0.025, n_days)),
-})
+prices = pl.DataFrame(
+    {
+        "date": dates,
+        "AAPL": 100.0 * np.cumprod(1 + rng.normal(0.001, 0.020, n_days)),
+        "GOOGL": 150.0 * np.cumprod(1 + rng.normal(0.001, 0.025, n_days)),
+    }
+)
 
-positions = pl.DataFrame({
-    "date": dates,
-    "AAPL":  np.full(n_days, 10_000.0),
-    "GOOGL": np.full(n_days, 15_000.0),
-})
+positions = pl.DataFrame(
+    {
+        "date": dates,
+        "AAPL": np.full(n_days, 10_000.0),
+        "GOOGL": np.full(n_days, 15_000.0),
+    }
+)
 
 portfolio = Portfolio.from_cash_position(prices=prices, cash_position=positions, aum=1e6)
 
 # Performance metrics
-nav      = portfolio.nav_accumulated   # Cumulative additive NAV
-returns  = portfolio.returns           # Daily returns scaled by AUM
-drawdown = portfolio.drawdown          # Distance from high-water mark
+nav = portfolio.nav_accumulated  # Cumulative additive NAV
+returns = portfolio.returns  # Daily returns scaled by AUM
+drawdown = portfolio.drawdown  # Distance from high-water mark
 
 # Statistics
-stats  = portfolio.stats
+stats = portfolio.stats
 sharpe = stats.sharpe()["returns"]
-vol    = stats.volatility()["returns"]
+vol = stats.volatility()["returns"]
 ```
 
 ### Visualizations
 
 ```python
-fig = portfolio.plots.snapshot()                          # NAV + drawdown dashboard
-fig = portfolio.plots.lead_lag_ir_plot(start=-10, end=20) # Sharpe across position lags
+fig = portfolio.plots.snapshot()  # NAV + drawdown dashboard
+fig = portfolio.plots.lead_lag_ir_plot(start=-10, end=20)  # Sharpe across position lags
 fig = portfolio.plots.lagged_performance_plot(lags=[0, 1, 2, 3, 4])
 fig = portfolio.plots.correlation_heatmap()
 # fig.show()
@@ -303,7 +315,13 @@ cfg.report.save("output/config_report")  # → output/config_report.html
 n = 100
 _dates = pl.date_range(pl.date(2023, 1, 1), pl.date(2023, 1, 1) + pl.duration(days=n - 1), eager=True)
 _rng = np.random.default_rng(0)
-_prices = pl.DataFrame({"date": _dates, "AAPL": 100.0 + np.cumsum(_rng.normal(0, 1.0, n)), "GOOGL": 150.0 + np.cumsum(_rng.normal(0, 1.2, n))})
+_prices = pl.DataFrame(
+    {
+        "date": _dates,
+        "AAPL": 100.0 + np.cumsum(_rng.normal(0, 1.0, n)),
+        "GOOGL": 150.0 + np.cumsum(_rng.normal(0, 1.2, n)),
+    }
+)
 _mu = pl.DataFrame({"date": _dates, "AAPL": np.tanh(_rng.normal(0, 0.5, n)), "GOOGL": np.tanh(_rng.normal(0, 0.5, n))})
 cfg_engine = BasanosEngine(prices=_prices, mu=_mu, cfg=cfg)
 cfg_engine.config_report.save("output/config_with_sweep")

--- a/docs/factor-models.md
+++ b/docs/factor-models.md
@@ -46,8 +46,8 @@ import numpy as np
 returns = np.random.default_rng(0).normal(size=(200, 5))
 fm = FactorModel.from_returns(returns, k=2)
 
-fm.n_assets    # 5
-fm.n_factors   # 2
+fm.n_assets  # 5
+fm.n_factors  # 2
 fm.covariance  # reconstructed (5, 5) covariance matrix
 ```
 
@@ -83,12 +83,12 @@ from basanos.math import BasanosConfig, BasanosEngine, SlidingWindowConfig
 
 cfg = BasanosConfig(
     vola=16,
-    corr=32,    # unused in sliding_window mode but still required
+    corr=32,  # unused in sliding_window mode but still required
     clip=3.5,
-    shrink=0.5, # unused in sliding_window mode
+    shrink=0.5,  # unused in sliding_window mode
     aum=1e6,
     covariance_config=SlidingWindowConfig(
-        window=60,    # rolling window length W; rule of thumb: W >= 2 * n_assets
+        window=60,  # rolling window length W; rule of thumb: W >= 2 * n_assets
         n_factors=2,  # number of latent factors k; fewer = stronger regularisation
     ),
 )


### PR DESCRIPTION
Syncs `jebel-quant/rhiza` from **v1.7.1** to **v1.7.2**.

10 template-owned file(s) changed. No conflicts arose during the sync, so nothing
had to be resolved, and nothing was left unstaged in the working tree.

What v1.7.2 brings, per its changelog:

- Fixes the docker job failing on the Dockerfile the template ships (#1651, #1658)
- Adds an artifact-only deployment option to the book workflow, as a commented
  `deploy-pages: false` hint (#1660)
- Bumps `rhiza-task` to 1.5.0, `ruff-pre-commit` to v0.16.5, `uv-pre-commit` to v0.12.9
- Bumps the github-actions group with 6 updates (#1661)

Only template-owned paths are touched -- staged mechanically from
`.rhiza/template.lock`'s `files` list, never `git add --all`.

**No gates were run** -- run `/rhiza:quality` for a scorecard.
