### PR TITLE
refactor: derive the version from the git tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,27 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# Supplies the `version` that [project] declares dynamic, from `git describe`. Two
+# consequences worth knowing:
+#   * The build needs the tag to be visible. hatch-vcs does not fail without it -- it
+#     falls back to a dev version like 0.7.4.dev3+g<sha> -- so rhiza_release.yml checks
+#     the built distribution's filename against the tag, and its checkout uses
+#     fetch-depth: 0. An sdist carries the resolved number in PKG-INFO, so building from
+#     one needs no git.
+#   * Between tags the local version is the *next* patch as a dev release
+#     (guess-next-dev, the default), which is why nothing pins a fallback-version here:
+#     a wrong-looking version must surface as a release failure, not as a plausible
+#     constant.
+[tool.hatch.version]
+source = "vcs"
 
 [project]
 name = "basanos"
-version = "0.7.3"
+# Derived from the git tag by hatch-vcs (see [tool.hatch.version]) rather than written
+# here, so the tag is the single source of truth and a release is `git tag` alone -- no
+# bump commit, and no way for a number in this file to disagree with what was tagged.
+dynamic = ["version"]
 description = "Correlation-aware portfolio optimization and analytics for Python."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -216,8 +233,12 @@ ignore_missing_imports = true
 # is how a release can be offered a version that was already published.
 [tool.bumpversion]
 # No current_version and no [[tool.bumpversion.files]] entry for the project
-# version: bump-my-version reads and rewrites PEP 621 [project].version
-# natively, and duplicating the string is what lets the two drift apart.
+# version: [project].version is dynamic, derived from the git tag by hatch-vcs, so
+# there is no number in any file for a bump to rewrite. bump-my-version resolves the
+# current version from the newest reachable tag instead — the same answer hatch-vcs
+# gives — and still proposes the right next number, it just no longer writes it.
+# Adding an entry would fail rather than no-op: a `search` pattern that occurs zero
+# times is an error, and check-bumpversion-config reports it at commit time.
 allow_dirty = false
 # /rhiza:release commits and tags itself, so the regenerated CHANGELOG.md lands
 # in the bump commit. A bare `bump-my-version bump` would add a second commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,8 +127,15 @@ ty_version = "==0.0.77"
 # ref one patch behind (`... @ git+https://github.com/Jebel-Quant/pytest-rhiza@v0.2.0`), so
 # a bare migration would have both downgraded the conformance checks -- the drift the pin
 # exists to prevent -- and swapped a released wheel for a clone. Pinned exactly rather than
-# floored: a gate that moves under you is not a gate. Bumping it is a separate decision.
-pytest-rhiza = "pytest-rhiza==0.2.1"
+# floored: a gate that moves under you is not a gate.
+#
+# 0.6.0 is required by this repo's dynamic [project].version, not merely available: it is
+# the first release whose test_pyproject accepts a version derived from the VCS. Under
+# 0.2.1 three of its assertions read `[project].version` as the empty string and fail --
+# the required-field check, the semver shape, and the tag-agreement one -- because they
+# predate `dynamic = ["version"]` being a thing a rhiza project could do. 0.6.0 skips each
+# with a reason instead. jquantstats, which made this move first, pins the same version.
+pytest-rhiza = "pytest-rhiza==0.6.0"
 
 # Not set, on purpose:
 #   source-folder / tests-folder -- `src` and `tests` are already this repo's layout, and

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,6 @@ wheels = [
 
 [[package]]
 name = "basanos"
-version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "cvx-linalg" },


### PR DESCRIPTION
## What

`[project].version` is no longer written in `pyproject.toml`. hatch-vcs derives it from
the git tag, so the tag is the single source of truth:

```toml
[build-system]
requires = ["hatchling", "hatch-vcs"]

[project]
dynamic = ["version"]

[tool.hatch.version]
source = "vcs"
```

## Why

The version was written in the manifest and kept in step with the tag by hand — through
bump-my-version, and in some repos a second entry for the copy `uv.lock` recorded. That
is two or three copies of one number per release, each able to disagree with the others.
A derived version cannot disagree with git.

`uv` omits the version from the lock's own package block once it is dynamic, so that
copy is gone too. bump-my-version resolves the current version from the newest reachable
tag instead of a file, which is the same answer hatch-vcs gives — it still proposes the
right next number, it just no longer writes it anywhere.

## The second commit is a prerequisite, not a drive-by

Making the version dynamic on its own turns the required `rhiza-test` job **red**. This
repo pinned the conformance checks at `pytest-rhiza==0.2.1`, which predates a rhiza
project being able to derive its version; three of its assertions read the absent
`[project].version` as `''` and fail on it rather than skipping. `0.6.0` is the first
release that accepts a VCS-derived version, is what `rhiza-task` 1.7.0 already resolves
by default, and is what `jquantstats` pins, having made this move first.

## Verification

Run locally, not inferred:

| check | result |
|---|---|
| build at the newest tag | wheel is **exactly** that tag's version |
| build between tags | next patch as a dev release (`guess-next-dev`) |
| `uvx rhiza-task@1.7.0 rhiza-test` | 29 passed, 6 skipped (the written-version assertions) |
| `uvx rhiza-task@1.7.0 test` | pass |
| `uv lock --check` | no drift |
| CI's shallow, tagless checkout | `uv sync --locked` and the suite pass |

`rhiza_release.yml` at v1.8.0 already handles a derived version: it skips the
`uv version --short` comparison — which exits 2 on a dynamic project — and checks the
built distribution's filename against the tag instead. Its build job checks out with
`fetch-depth: 0`, which hatch-vcs needs to see the tag.

## Note for the reviewer

The one behaviour that genuinely changes: between tags, a local build or editable install
now reports a dev version (`X.Y.(Z+1).devN+g<sha>`) rather than the last release number.
That is the point — a number that looks wrong now surfaces as a release failure instead
of as a plausible constant — but it is worth knowing before the first `pip show`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
